### PR TITLE
Type model and API rework

### DIFF
--- a/src/ARCTokenization/Address.fs
+++ b/src/ARCTokenization/Address.fs
@@ -4,11 +4,11 @@ open ControlledVocabulary
 
 module Address = 
 
-    let column : CvTerm = "http://purl.obolibrary.org/obo/NCIT_C43379","Column","NCIT"
+    let column = CvTerm.create(accession = "http://purl.obolibrary.org/obo/NCIT_C43379", value = "Column", ref = "NCIT")
 
-    let row : CvTerm = "http://purl.obolibrary.org/obo/NCIT_C43378","Row","NCIT"
+    let row = CvTerm.create(accession = "http://purl.obolibrary.org/obo/NCIT_C43378", value = "Row", ref = "NCIT")
 
-    let worksheet : CvTerm = "http://purl.obolibrary.org/obo/NCIT_C73541","Worksheet","NCIT"
+    let worksheet = CvTerm.create(accession = "http://purl.obolibrary.org/obo/NCIT_C73541", value = "Worksheet", ref = "NCIT")
 
     //"isa_investigation!A1"
 

--- a/src/ARCTokenization/Address.fs
+++ b/src/ARCTokenization/Address.fs
@@ -4,11 +4,11 @@ open ControlledVocabulary
 
 module Address = 
 
-    let column = CvTerm.create(accession = "http://purl.obolibrary.org/obo/NCIT_C43379", value = "Column", ref = "NCIT")
+    let column = CvTerm.create(accession = "http://purl.obolibrary.org/obo/NCIT_C43379", name = "Column", ref = "NCIT")
 
-    let row = CvTerm.create(accession = "http://purl.obolibrary.org/obo/NCIT_C43378", value = "Row", ref = "NCIT")
+    let row = CvTerm.create(accession = "http://purl.obolibrary.org/obo/NCIT_C43378", name = "Row", ref = "NCIT")
 
-    let worksheet = CvTerm.create(accession = "http://purl.obolibrary.org/obo/NCIT_C73541", value = "Worksheet", ref = "NCIT")
+    let worksheet = CvTerm.create(accession = "http://purl.obolibrary.org/obo/NCIT_C73541", name = "Worksheet", ref = "NCIT")
 
     //"isa_investigation!A1"
 

--- a/src/ARCTokenization/AnnotationTable.fs
+++ b/src/ARCTokenization/AnnotationTable.fs
@@ -151,7 +151,7 @@ module AnnotationTable =
                     let cvPars =
                         List.map4 (
                             fun (vl : FsCell) unt tan tsr -> 
-                                let valTerm = CvUnit.create(accession = tan.Value, value = vl.Value, ref = tsr.Value)
+                                let valTerm = CvUnit.create(accession = tan.Value, name = vl.Value, ref = tsr.Value)
                                 CvParam(d.Value, a.Value, c.Value, WithCvUnitAccession (unt.Value, valTerm))
                         ) dataCellsVal dataCellsUnt dataCellsTan dataCellsTsr 
                     yield! cvPars
@@ -166,7 +166,7 @@ module AnnotationTable =
                         (dataCellsVal, dataCellsTsr, dataCellsTan)
                         |||> List.map3 (
                             fun vl tsr tan ->
-                                let valTerm = CvTerm.create(accession = tan.Value, value = vl.Value, ref = tsr.Value)
+                                let valTerm = CvTerm.create(accession = tan.Value, name = vl.Value, ref = tsr.Value)
                                 CvParam(c.Value, a.Value, b.Value, CvValue valTerm)
                         )
                     yield! cvPars
@@ -182,7 +182,7 @@ module AnnotationTable =
                             (dataCellsVal, dataCellsTsr)
                             ||> List.map2 (
                                 fun vl tsr ->
-                                    let valTerm = CvTerm.create (accession = "(n/a)", value = vl.Value, ref = tsr.Value)
+                                    let valTerm = CvTerm.create (accession = "(n/a)", name = vl.Value, ref = tsr.Value)
                                     CvParam("n/a", a.Value, b.Value, CvValue valTerm)
                             )
                         yield! cvPars
@@ -195,7 +195,7 @@ module AnnotationTable =
                             (dataCellsTsr, dataCellsTan)
                             ||> List.map2 (
                                 fun tsr tan ->
-                                    let valTerm = CvTerm.create(accession = tan.Value, value = "n/a", ref = tsr.Value)
+                                    let valTerm = CvTerm.create(accession = tan.Value, name = "n/a", ref = tsr.Value)
                                     CvParam(b.Value, "(n/a)", a.Value, CvValue valTerm)
                             )
                         yield! cvPars
@@ -291,7 +291,7 @@ module AnnotationTable =
     let getNodeType (cvPar : #IParamBase) =
         //let castedCvPar = cvPar :?> CvParam<string>     // debatable approach
         //let v = Param.getCvName castedCvPar
-        let v = CvBase.getCvValue cvPar
+        let v = CvBase.getCvName cvPar
         match v with
         | "Source Name" -> Source
         | "Sample Name"

--- a/src/ARCTokenization/AnnotationTable.fs
+++ b/src/ARCTokenization/AnnotationTable.fs
@@ -151,7 +151,7 @@ module AnnotationTable =
                     let cvPars =
                         List.map4 (
                             fun (vl : FsCell) unt tan tsr -> 
-                                let valTerm = CvUnit(tan.Value, vl.Value, tsr.Value)
+                                let valTerm = CvUnit.create(accession = tan.Value, value = vl.Value, ref = tsr.Value)
                                 CvParam(d.Value, a.Value, c.Value, WithCvUnitAccession (unt.Value, valTerm))
                         ) dataCellsVal dataCellsUnt dataCellsTan dataCellsTsr 
                     yield! cvPars
@@ -166,7 +166,7 @@ module AnnotationTable =
                         (dataCellsVal, dataCellsTsr, dataCellsTan)
                         |||> List.map3 (
                             fun vl tsr tan ->
-                                let valTerm = CvTerm(tan.Value, vl.Value, tsr.Value)
+                                let valTerm = CvTerm.create(accession = tan.Value, value = vl.Value, ref = tsr.Value)
                                 CvParam(c.Value, a.Value, b.Value, CvValue valTerm)
                         )
                     yield! cvPars
@@ -182,7 +182,7 @@ module AnnotationTable =
                             (dataCellsVal, dataCellsTsr)
                             ||> List.map2 (
                                 fun vl tsr ->
-                                    let valTerm = CvTerm("(n/a)", vl.Value, tsr.Value)
+                                    let valTerm = CvTerm.create (accession = "(n/a)", value = vl.Value, ref = tsr.Value)
                                     CvParam("n/a", a.Value, b.Value, CvValue valTerm)
                             )
                         yield! cvPars
@@ -195,7 +195,7 @@ module AnnotationTable =
                             (dataCellsTsr, dataCellsTan)
                             ||> List.map2 (
                                 fun tsr tan ->
-                                    let valTerm = CvTerm(tan.Value, "n/a", tsr.Value)
+                                    let valTerm = CvTerm.create(accession = tan.Value, value = "n/a", ref = tsr.Value)
                                     CvParam(b.Value, "(n/a)", a.Value, CvValue valTerm)
                             )
                         yield! cvPars
@@ -291,7 +291,7 @@ module AnnotationTable =
     let getNodeType (cvPar : #IParamBase) =
         //let castedCvPar = cvPar :?> CvParam<string>     // debatable approach
         //let v = Param.getCvName castedCvPar
-        let v = CvBase.getCvName cvPar
+        let v = CvBase.getCvValue cvPar
         match v with
         | "Source Name" -> Source
         | "Sample Name"

--- a/src/ARCTokenization/MetadataSheet.fs
+++ b/src/ARCTokenization/MetadataSheet.fs
@@ -9,7 +9,7 @@ module MetadataSheet =
 
     let (|Term|_|) (terms : CvTerm list) (key : string) : CvTerm Option =
         terms 
-        |> List.tryFind (fun (term) -> CvTerm.getName term = key)
+        |> List.tryFind (fun (term) -> term.Value = key)
 
     let (|UnMatchable|) (key : string) : string =
         key

--- a/src/ARCTokenization/MetadataSheet.fs
+++ b/src/ARCTokenization/MetadataSheet.fs
@@ -9,7 +9,7 @@ module MetadataSheet =
 
     let (|Term|_|) (terms : CvTerm list) (key : string) : CvTerm Option =
         terms 
-        |> List.tryFind (fun (term) -> term.Value = key)
+        |> List.tryFind (fun (term) -> term.Name = key)
 
     let (|UnMatchable|) (key : string) : string =
         key

--- a/src/ARCTokenization/Terms.fs
+++ b/src/ARCTokenization/Terms.fs
@@ -24,7 +24,7 @@ module InvestigationMetadata =
 
     let cvTerms = 
         ontology.Terms
-        |> List.map (fun t -> CvTerm.create(accession = t.Id, value = t.Name, ref = "INVMSO"))
+        |> List.map (fun t -> CvTerm.create(accession = t.Id, name = t.Name, ref = "INVMSO"))
 
 module StudyMetadata =
     
@@ -34,7 +34,7 @@ module StudyMetadata =
 
     let cvTerms = 
         ontology.Terms
-        |> List.map (fun t -> CvTerm.create(accession = t.Id, value = t.Name, ref ="STDMSO"))    
+        |> List.map (fun t -> CvTerm.create(accession = t.Id, name = t.Name, ref ="STDMSO"))    
 
 module AssayMetadata = 
     
@@ -44,8 +44,8 @@ module AssayMetadata =
 
     let cvTerms = 
         ontology.Terms
-        |> List.map (fun t -> CvTerm.create(accession = t.Id, value = t.Name, ref ="ASSMSO"))
+        |> List.map (fun t -> CvTerm.create(accession = t.Id, name = t.Name, ref ="ASSMSO"))
 
 module StructuralTerms =
     
-    let metadataSectionKey = CvTerm.create(accession = "AGMO:00000001", value = "Metadata Section Key", ref = "AGMO")
+    let metadataSectionKey = CvTerm.create(accession = "AGMO:00000001", name = "Metadata Section Key", ref = "AGMO")

--- a/src/ARCTokenization/Terms.fs
+++ b/src/ARCTokenization/Terms.fs
@@ -24,7 +24,7 @@ module InvestigationMetadata =
 
     let cvTerms = 
         ontology.Terms
-        |> List.map (fun t -> CvTerm(t.Id,t.Name,"INVMSO"))
+        |> List.map (fun t -> CvTerm.create(accession = t.Id, value = t.Name, ref = "INVMSO"))
 
 module StudyMetadata =
     
@@ -34,7 +34,7 @@ module StudyMetadata =
 
     let cvTerms = 
         ontology.Terms
-        |> List.map (fun t -> CvTerm(t.Id,t.Name,"STDMSO"))    
+        |> List.map (fun t -> CvTerm.create(accession = t.Id, value = t.Name, ref ="STDMSO"))    
 
 module AssayMetadata = 
     
@@ -44,8 +44,8 @@ module AssayMetadata =
 
     let cvTerms = 
         ontology.Terms
-        |> List.map (fun t -> CvTerm(t.Id,t.Name,"ASSMSO"))
+        |> List.map (fun t -> CvTerm.create(accession = t.Id, value = t.Name, ref ="ASSMSO"))
 
 module StructuralTerms =
     
-    let metadataSectionKey = CvTerm("AGMO:00000001","Metadata Section Key","AGMO")
+    let metadataSectionKey = CvTerm.create(accession = "AGMO:00000001", value = "Metadata Section Key", ref = "AGMO")

--- a/src/ControlledVocabulary/CvAttributeCollection.fs
+++ b/src/ControlledVocabulary/CvAttributeCollection.fs
@@ -12,7 +12,7 @@ type CvAttributeCollection(attributes : IDictionary<string,IParam>) =
     new(attributes) =
         let dict = 
             attributes
-            |> Seq.map (fun cvp -> (cvp :> ICvBase).Name, cvp)
+            |> Seq.map (fun cvp -> (cvp :> ICvBase).Value, cvp)
             |> Dictionary.ofSeq
         CvAttributeCollection(dict)
 
@@ -22,12 +22,12 @@ type CvAttributeCollection(attributes : IDictionary<string,IParam>) =
 
     /// Add an IParam as an attribute. Fails, if an attribute with the same key already exists
     member this.AddAttribute (param : IParam) =
-        Dictionary.addInPlace (param |> CvBase.getCvName) param this
+        Dictionary.addInPlace (param |> CvBase.getCvValue) param this
         |> ignore
 
     /// Add an IParam as an attribute. Does not fail, if an attribute with the same key already exists
     member this.TryAddAttribute (param : IParam) =
-        let key = param |> CvBase.getCvName 
+        let key = param |> CvBase.getCvValue 
         if this.ContainsAttribute key then false
         else 
             this.AddAttribute param
@@ -39,7 +39,7 @@ type CvAttributeCollection(attributes : IDictionary<string,IParam>) =
 
     /// Retrieves an IParam attribute by its term, if it exists, else returns None
     member this.TryGetAttribute (term : CvTerm) =
-        Dictionary.tryFind (CvTerm.getName term) this
+        Dictionary.tryFind term.Value this
         |> Option.bind (fun param -> 
             if CvBase.equalsTerm term param then 
                 Some param 
@@ -51,7 +51,7 @@ type CvAttributeCollection(attributes : IDictionary<string,IParam>) =
 
     /// Retrieves an IParam attribute by its term, if it exists, else fails
     member this.GetAttribute (term : CvTerm) =
-        Dictionary.item (CvTerm.getName term) this
+        Dictionary.item term.Value this
 
     /// Returns true, if an attribute with the given name exists in the collection
     member this.ContainsAttribute (name : string) =
@@ -59,7 +59,7 @@ type CvAttributeCollection(attributes : IDictionary<string,IParam>) =
 
     /// Returns true, if an attribute with the given term exists in the collection
     member this.ContainsAttribute (term : CvTerm) =
-        match Dictionary.tryFind (CvTerm.getName term) this with
+        match Dictionary.tryFind term.Value this with
         | Some param when CvBase.equalsTerm term param -> true
         | _ -> false
 

--- a/src/ControlledVocabulary/CvAttributeCollection.fs
+++ b/src/ControlledVocabulary/CvAttributeCollection.fs
@@ -12,7 +12,7 @@ type CvAttributeCollection(attributes : IDictionary<string,IParam>) =
     new(attributes) =
         let dict = 
             attributes
-            |> Seq.map (fun cvp -> (cvp :> ICvBase).Value, cvp)
+            |> Seq.map (fun cvp -> (cvp :> ICvBase).Name, cvp)
             |> Dictionary.ofSeq
         CvAttributeCollection(dict)
 
@@ -22,12 +22,12 @@ type CvAttributeCollection(attributes : IDictionary<string,IParam>) =
 
     /// Add an IParam as an attribute. Fails, if an attribute with the same key already exists
     member this.AddAttribute (param : IParam) =
-        Dictionary.addInPlace (param |> CvBase.getCvValue) param this
+        Dictionary.addInPlace (param |> CvBase.getCvName) param this
         |> ignore
 
     /// Add an IParam as an attribute. Does not fail, if an attribute with the same key already exists
     member this.TryAddAttribute (param : IParam) =
-        let key = param |> CvBase.getCvValue 
+        let key = param |> CvBase.getCvName 
         if this.ContainsAttribute key then false
         else 
             this.AddAttribute param
@@ -39,7 +39,7 @@ type CvAttributeCollection(attributes : IDictionary<string,IParam>) =
 
     /// Retrieves an IParam attribute by its term, if it exists, else returns None
     member this.TryGetAttribute (term : CvTerm) =
-        Dictionary.tryFind term.Value this
+        Dictionary.tryFind term.Name this
         |> Option.bind (fun param -> 
             if CvBase.equalsTerm term param then 
                 Some param 
@@ -51,7 +51,7 @@ type CvAttributeCollection(attributes : IDictionary<string,IParam>) =
 
     /// Retrieves an IParam attribute by its term, if it exists, else fails
     member this.GetAttribute (term : CvTerm) =
-        Dictionary.item term.Value this
+        Dictionary.item term.Name this
 
     /// Returns true, if an attribute with the given name exists in the collection
     member this.ContainsAttribute (name : string) =
@@ -59,7 +59,7 @@ type CvAttributeCollection(attributes : IDictionary<string,IParam>) =
 
     /// Returns true, if an attribute with the given term exists in the collection
     member this.ContainsAttribute (term : CvTerm) =
-        match Dictionary.tryFind term.Value this with
+        match Dictionary.tryFind term.Name this with
         | Some param when CvBase.equalsTerm term param -> true
         | _ -> false
 

--- a/src/ControlledVocabulary/CvContainer.fs
+++ b/src/ControlledVocabulary/CvContainer.fs
@@ -13,18 +13,18 @@ module internal Dictionary =
 /// Represents a collection of structured properties, annotated with a controlled vocabulary term.
 type CvContainer (
     cvAccession : string, 
-    cvName : string, 
-    cvRefUri : string, 
-    attributes : IDictionary<string,IParam>,
-    properties : IDictionary<string,seq<ICvBase>>
+    cvValue     : string, 
+    cvRef       : string, 
+    attributes  : IDictionary<string,IParam>,
+    properties  : IDictionary<string,seq<ICvBase>>
     ) =
 
     inherit CvAttributeCollection(attributes)
 
     interface ICvBase with 
-        member this.ID     = cvAccession
-        member this.Name   = cvName
-        member this.RefUri = cvRefUri    
+        member this.Accession   = cvAccession
+        member this.Value       = cvValue
+        member this.RefUri         = cvRef
         member this.HasAttributes 
             with get() = this.Attributes |> Seq.isEmpty |> not
 
@@ -37,8 +37,8 @@ type CvContainer (
         CvContainer(cvAccession, cvName, cvRefUri, Seq.empty)
 
 
-    new ((id,name,ref) : CvTerm, attributes : IDictionary<string,IParam>) = 
-        CvContainer(id,name,ref, attributes, Dictionary<string, ICvBase seq>())
+    new (term : CvTerm, attributes : IDictionary<string,IParam>) = 
+        CvContainer(term.Accession, term.Value, term.RefUri, attributes, Dictionary<string, ICvBase seq>())
     new (term : CvTerm,attributes : seq<IParam>) = 
         let dict = CvAttributeCollection(attributes)
         CvContainer(term, dict)
@@ -307,7 +307,7 @@ type CvContainer (
     ///
     /// If a value with the same key already exist in the container, appends the new child
     static member addSingle (value : ICvBase) (cvContainer : CvContainer) =
-        Dictionary.addOrAppendInPlace value.Name value cvContainer.Properties
+        Dictionary.addOrAppendInPlace value.Value value cvContainer.Properties
         
 
     /// Sets children as a property of the CvContainer.
@@ -319,7 +319,7 @@ type CvContainer (
     static member setMany (values : seq<ICvBase>) (cvContainer : CvContainer) =
         let propertyName = 
             values
-            |> Seq.countBy (fun v -> v.Name)
+            |> Seq.countBy (fun v -> v.Value)
             |> Seq.exactlyOne
             |> fst
         Dictionary.addOrUpdateInPlace propertyName values cvContainer.Properties
@@ -327,7 +327,7 @@ type CvContainer (
 
     /// Sets a single child as a property of the CvContainer, accessible by its name.
     static member setSingle (value : ICvBase) (cvContainer : CvContainer) =
-        Dictionary.addOrUpdateInPlace value.Name (Seq.singleton value) cvContainer.Properties
+        Dictionary.addOrUpdateInPlace value.Value (Seq.singleton value) cvContainer.Properties
 
     override this.ToString() = 
-        $"CvContainer: {(this :> ICvBase).Name}\n\tID: {(this :> ICvBase).ID}\n\tRefUri: {(this :> ICvBase).RefUri}\n\tProperties: {this.Properties.Keys |> Seq.toList}"
+        $"CvContainer: {(this :> ICvBase).Value}\n\tID: {(this :> ICvBase).Accession}\n\tRefUri: {(this :> ICvBase).RefUri}\n\tProperties: {this.Properties.Keys |> Seq.toList}"

--- a/src/ControlledVocabulary/CvContainer.fs
+++ b/src/ControlledVocabulary/CvContainer.fs
@@ -13,7 +13,7 @@ module internal Dictionary =
 /// Represents a collection of structured properties, annotated with a controlled vocabulary term.
 type CvContainer (
     cvAccession : string, 
-    cvValue     : string, 
+    cvName     : string, 
     cvRef       : string, 
     attributes  : IDictionary<string,IParam>,
     properties  : IDictionary<string,seq<ICvBase>>
@@ -23,8 +23,8 @@ type CvContainer (
 
     interface ICvBase with 
         member this.Accession   = cvAccession
-        member this.Value       = cvValue
-        member this.RefUri         = cvRef
+        member this.Name        = cvName
+        member this.RefUri      = cvRef
         member this.HasAttributes 
             with get() = this.Attributes |> Seq.isEmpty |> not
 
@@ -38,7 +38,7 @@ type CvContainer (
 
 
     new (term : CvTerm, attributes : IDictionary<string,IParam>) = 
-        CvContainer(term.Accession, term.Value, term.RefUri, attributes, Dictionary<string, ICvBase seq>())
+        CvContainer(term.Accession, term.Name, term.RefUri, attributes, Dictionary<string, ICvBase seq>())
     new (term : CvTerm,attributes : seq<IParam>) = 
         let dict = CvAttributeCollection(attributes)
         CvContainer(term, dict)
@@ -307,7 +307,7 @@ type CvContainer (
     ///
     /// If a value with the same key already exist in the container, appends the new child
     static member addSingle (value : ICvBase) (cvContainer : CvContainer) =
-        Dictionary.addOrAppendInPlace value.Value value cvContainer.Properties
+        Dictionary.addOrAppendInPlace value.Name value cvContainer.Properties
         
 
     /// Sets children as a property of the CvContainer.
@@ -319,7 +319,7 @@ type CvContainer (
     static member setMany (values : seq<ICvBase>) (cvContainer : CvContainer) =
         let propertyName = 
             values
-            |> Seq.countBy (fun v -> v.Value)
+            |> Seq.countBy (fun v -> v.Name)
             |> Seq.exactlyOne
             |> fst
         Dictionary.addOrUpdateInPlace propertyName values cvContainer.Properties
@@ -327,7 +327,7 @@ type CvContainer (
 
     /// Sets a single child as a property of the CvContainer, accessible by its name.
     static member setSingle (value : ICvBase) (cvContainer : CvContainer) =
-        Dictionary.addOrUpdateInPlace value.Value (Seq.singleton value) cvContainer.Properties
+        Dictionary.addOrUpdateInPlace value.Name (Seq.singleton value) cvContainer.Properties
 
     override this.ToString() = 
-        $"CvContainer: {(this :> ICvBase).Value}\n\tID: {(this :> ICvBase).Accession}\n\tRefUri: {(this :> ICvBase).RefUri}\n\tProperties: {this.Properties.Keys |> Seq.toList}"
+        $"CvContainer: {(this :> ICvBase).Name}\n\tID: {(this :> ICvBase).Accession}\n\tRefUri: {(this :> ICvBase).RefUri}\n\tProperties: {this.Properties.Keys |> Seq.toList}"

--- a/src/ControlledVocabulary/CvContainer.fs
+++ b/src/ControlledVocabulary/CvContainer.fs
@@ -79,7 +79,7 @@ type CvContainer (
     /// Fails if the propertyName cannot be found.
     member this.GetManyParams propertyName =
         Dictionary.item propertyName this.Properties
-        |> Seq.choose Param.tryParam
+        |> Seq.choose CvBase.tryParam
 
     /// Retrieves child with the given name of the CvContainer.
     ///
@@ -109,7 +109,7 @@ type CvContainer (
     /// Fails if there is not exactly one child with the given name or if the propertyName cannot be found.
     member this.GetSingleParam propertyName =
         Dictionary.item propertyName this.Properties
-        |> Seq.choose Param.tryParam
+        |> Seq.choose CvBase.tryParam
         |> Seq.exactlyOne
         
 
@@ -146,7 +146,7 @@ type CvContainer (
         Dictionary.tryFind propertyName this.Properties
         |> Option.bind (fun many ->
             many
-            |> Seq.choose Param.tryParam
+            |> Seq.choose CvBase.tryParam
             |> fun items -> if Seq.isEmpty items then None else Some items
         )
 
@@ -176,7 +176,7 @@ type CvContainer (
     /// Returns None if there is not exactly one child with the given name or if the propertyName cannot be found.
     member this.TryGetSingleParam propertyName =
         Dictionary.tryFind propertyName this.Properties
-        |> Option.bind (Seq.choose Param.tryParam >> Seq.tryExactlyOne)
+        |> Option.bind (Seq.choose CvBase.tryParam >> Seq.tryExactlyOne)
 
     
 

--- a/src/ControlledVocabulary/CvObject.fs
+++ b/src/ControlledVocabulary/CvObject.fs
@@ -3,20 +3,20 @@
 open System.Collections.Generic
 
 /// Represents a generic object, annotated with a controlled vocabulary term
-type CvObject<'T>(cvAccession : string, cvValue : string, cvRef : string, object : 'T, attributes : Dictionary<string,IParam>) =
+type CvObject<'T>(cvAccession : string, cvName : string, cvRef : string, object : 'T, attributes : Dictionary<string,IParam>) =
 
     inherit CvAttributeCollection(attributes)
 
     interface ICvBase with 
         member this.Accession   = cvAccession
-        member this.Value       = cvValue
+        member this.Name        = cvName
         member this.RefUri         = cvRef
         member this.HasAttributes 
             with get() = this.Attributes |> Seq.isEmpty |> not
 
-    new (term: CvTerm, object : 'T, attributes) = CvObject (term.Accession, term.Value, term.RefUri, object, attributes)
+    new (term: CvTerm, object : 'T, attributes) = CvObject (term.Accession, term.Name, term.RefUri, object, attributes)
 
     member this.Object = object
 
     override this.ToString() = 
-        $"Name: {(this :> ICvBase).Value}\n\tID: {(this :> ICvBase).Accession}\n\tRefUri: {(this :> ICvBase).RefUri}"
+        $"Name: {(this :> ICvBase).Name}\n\tID: {(this :> ICvBase).Accession}\n\tRefUri: {(this :> ICvBase).RefUri}"

--- a/src/ControlledVocabulary/CvObject.fs
+++ b/src/ControlledVocabulary/CvObject.fs
@@ -3,20 +3,20 @@
 open System.Collections.Generic
 
 /// Represents a generic object, annotated with a controlled vocabulary term
-type CvObject<'T>(cvAccession : string, cvName : string, cvRefUri : string, object : 'T, attributes : Dictionary<string,IParam>) =
+type CvObject<'T>(cvAccession : string, cvValue : string, cvRef : string, object : 'T, attributes : Dictionary<string,IParam>) =
 
     inherit CvAttributeCollection(attributes)
 
     interface ICvBase with 
-        member this.ID     = cvAccession
-        member this.Name   = cvName
-        member this.RefUri = cvRefUri
+        member this.Accession   = cvAccession
+        member this.Value       = cvValue
+        member this.RefUri         = cvRef
         member this.HasAttributes 
             with get() = this.Attributes |> Seq.isEmpty |> not
 
-    new ((id,name,ref) : CvTerm,object : 'T, attributes) = CvObject (id,name,ref,object,attributes)
+    new (term: CvTerm, object : 'T, attributes) = CvObject (term.Accession, term.Value, term.RefUri, object, attributes)
 
     member this.Object = object
 
     override this.ToString() = 
-        $"Name: {(this :> ICvBase).Name}\n\tID: {(this :> ICvBase).ID}\n\tRefUri: {(this :> ICvBase).RefUri}"
+        $"Name: {(this :> ICvBase).Value}\n\tID: {(this :> ICvBase).Accession}\n\tRefUri: {(this :> ICvBase).RefUri}"

--- a/src/ControlledVocabulary/CvParam.fs
+++ b/src/ControlledVocabulary/CvParam.fs
@@ -47,28 +47,6 @@ type CvParam(cvAccession : string, cvName : string, cvRef : string, paramValue :
     member this.Equals (cvp : CvParam) =
         this.Equals(cvp :> ICvBase)
 
-    /// Returns Some Param if the given cv item can be downcast, else returns None
-    static member tryCvParam (cv : ICvBase) =
-        match cv with
-        | :? CvParam as param -> Some param
-        | _ -> None
-
-    /// Returns Some Param if the given value item can be downcast, else returns None
-    static member tryCvParam (cv : IParamBase) =
-        match cv with
-        | :? CvParam as param -> Some param
-        | _ -> None
-
-    /// Returns Some Param if the given param item can be downcast, else returns None
-    static member tryCvParam (cv : IParam) =
-        match cv with
-        | :? CvParam as param -> Some param
-        | _ -> None
-
-    /// Returns true, if the given value item can be downcast to CvParam
-    static member isCvParam (cv : ICvBase) = 
-        CvBase.is<CvParam> cv
-
     /// Create a CvParam from a category and a simple value
     static member fromValue (category : CvTerm) (v : 'T) =
         CvParam(category, ParamValue.Value (v :> IConvertible))
@@ -108,3 +86,31 @@ type CvParam(cvAccession : string, cvName : string, cvRef : string, paramValue :
 
     member this.DisplayText = 
         this.ToString()
+
+[<AutoOpen>]
+module CvParamExtensions = 
+
+    type ParamBase with
+        /// Returns Some Param if the given value item can be downcast, else returns None
+        static member tryCvParam (cv : IParamBase) =
+            match cv with
+            | :? CvParam as param -> Some param
+            | _ -> None
+
+    type Param with
+        /// Returns Some Param if the given param item can be downcast, else returns None
+        static member tryCvParam (cv : IParam) =
+            match cv with
+            | :? CvParam as param -> Some param
+            | _ -> None
+
+    type CvBase with
+        /// Returns Some Param if the given cv item can be downcast, else returns None
+        static member tryCvParam (cv : ICvBase) =
+            match cv with
+            | :? CvParam as param -> Some param
+            | _ -> None
+
+        /// Returns true, if the given value item can be downcast to CvParam
+        static member isCvParam (cv : ICvBase) = 
+            CvBase.is<CvParam> cv

--- a/src/ControlledVocabulary/CvParam.fs
+++ b/src/ControlledVocabulary/CvParam.fs
@@ -14,11 +14,17 @@ type CvParam(cvAccession : string, cvName : string, cvRef : string, paramValue :
 
     inherit CvAttributeCollection(attributes)
 
+    member this.Accession   = cvAccession
+    member this.Name        = cvName
+    member this.RefUri      = cvRef
+    member this.Value       = paramValue
+    member this.WithValue(v : ParamValue) = CvParam(cvAccession,cvName,cvRef,v,attributes)
+
     interface IParam with 
-        member this.Accession   = cvAccession
-        member this.Name        = cvName
-        member this.RefUri      = cvRef
-        member this.Value       = paramValue
+        member this.Accession   = this.Accession
+        member this.Name        = this.Name     
+        member this.RefUri      = this.RefUri   
+        member this.Value       = this.Value    
         member this.WithValue(v : ParamValue) = CvParam(cvAccession,cvName,cvRef,v,attributes)
         member this.HasAttributes 
             with get() = this.Attributes |> Seq.isEmpty |> not

--- a/src/ControlledVocabulary/CvParam.fs
+++ b/src/ControlledVocabulary/CvParam.fs
@@ -45,13 +45,95 @@ type CvParam(cvAccession : string, cvName : string, cvRef : string, paramValue :
         CvParam (cvTerm,ParamValue.Value v)
 
     member this.Equals (term : CvTerm) = 
-        CvBase.equalsTerm term this
+        Param.equalsTerm term this
 
     member this.Equals (cv : ICvBase) = 
         CvBase.equals cv this
 
     member this.Equals (cvp : CvParam) =
         this.Equals(cvp :> ICvBase)
+
+    //---------------------- IParam implementations ----------------------//
+
+    /// Returns the value of the Param as a ParamValue
+    static member getParamValue (cvp: CvParam) = Param.getParamValue cvp
+
+    /// Returns the value of the Param as IConvertible
+    static member getValue (cvp: CvParam) = Param.getValue cvp
+
+    /// Returns the value of the Param as string
+    static member getValueAsString (cvp: CvParam) = Param.getValueAsString cvp
+        
+    /// Returns the value of the Param as int if possible, else fails
+    static member getValueAsInt (cvp: CvParam) = Param.getValueAsInt cvp
+
+    /// Returns the value of the Param as a term
+    static member getValueAsTerm (cvp: CvParam) = Param.getValueAsTerm cvp
+
+    static member tryGetValueAccession (cvp: CvParam) = Param.tryGetValueAccession cvp
+
+    static member tryGetValueRef (cvp: CvParam) = Param.tryGetValueRef cvp
+
+    static member tryGetCvUnit (cvp: CvParam) : CvUnit option = Param.tryGetCvUnit cvp
+
+    static member tryGetCvUnitValue (cvp: CvParam) = Param.tryGetCvUnitValue cvp
+
+    static member tryGetCvUnitTermName (cvp: CvParam) = Param.tryGetCvUnitTermName cvp
+
+    static member tryGetCvUnitTermAccession (cvp: CvParam) = Param.tryGetCvUnitTermAccession cvp
+
+    static member tryGetCvUnitTermRef (cvp: CvParam) = Param.tryGetCvUnitTermRef cvp
+
+    static member mapValue (f : ParamValue -> ParamValue) (cvp: CvParam) = Param.mapValue f cvp :?> CvParam
+
+    static member tryMapValue (f : ParamValue -> ParamValue option) (cvp: CvParam) = 
+        Param.tryMapValue f cvp 
+        |> Option.map (fun v -> v :?> CvParam)
+
+    static member tryAddName (name : string) (cvp: CvParam) = 
+        Param.tryAddName name cvp
+        |> Option.map (fun v -> v :?> CvParam)
+
+    static member tryAddAccession (acc : string) (cvp: CvParam) = 
+        Param.tryAddAccession acc cvp
+        |> Option.map (fun v -> v :?> CvParam)
+
+    static member tryAddReference (ref : string) (cvp: CvParam) = 
+        Param.tryAddReference ref cvp
+        |> Option.map (fun v -> v :?> CvParam)
+
+    static member tryAddUnit (unit : CvUnit) (cvp: CvParam) = 
+        Param.tryAddUnit unit cvp
+        |> Option.map (fun v -> v :?> CvParam)
+
+    /// Returns the id of the cv item
+    static member getCvAccession (cvp: CvParam) = Param.getCvAccession cvp
+
+    /// Returns the name of the cv item
+    static member getCvName (cvp: CvParam) = Param.getCvName cvp
+
+    /// Returns the reference of the cv item
+    static member getCvRef (cvp: CvParam) = Param.getCvRef cvp
+
+    /// Returns the full term of the cv item
+    static member getTerm (cvp: CvParam) = Param.getTerm cvp
+
+    /// Returns true, if the given term matches the term of the cv item
+    static member equalsTerm (term : CvTerm) (cvp: CvParam) = Param.equalsTerm term cvp
+
+    /// Returns true, if the terms of the given param items match
+    static member equals (cvp1 : CvParam) (cvp2 : CvParam) = Param.equals cvp1 cvp2
+
+    /// Returns true, if the names of the given param items match
+    static member equalsName (cvp1 : CvParam) (cvp2 : CvParam) = Param.equalsName cvp1 cvp1
+
+    /// Returns Some Value of type 'T, if the given param item can be downcast, else returns None
+    static member inline tryAs<'T when 'T :> IParam> (cvp: CvParam) = Param.tryAs<'T> cvp
+
+    /// Returns true, if the given param item can be downcast
+    static member inline is<'T when 'T :> IParam> (cvp: CvParam) = Param.is<'T> cvp
+
+    //---------------------- CvParam specific implementations ----------------------//
 
     /// Create a CvParam from a category and a simple value
     static member fromValue (category : CvTerm) (v : 'T) =
@@ -65,27 +147,8 @@ type CvParam(cvAccession : string, cvName : string, cvRef : string, paramValue :
     static member fromValueWithUnit (category : CvTerm) (v : 'T) (unit : CvUnit) =
         CvParam(category, ParamValue.WithCvUnitAccession (v :> IConvertible,unit))
 
-    static member mapValue (f : ParamValue -> ParamValue) (param : CvParam) = 
-        Param.mapValue f param
-
-    static member tryMapValue (f : ParamValue -> ParamValue option) (param : CvParam) = 
-        Param.tryMapValue f param
-
-    static member tryAddName (value : string) (param : CvParam) = 
-        Param.tryAddName value param
-
-    static member tryAddAccession (id : string) (param : CvParam) = 
-        Param.tryAddAccession id param
-
-    static member tryAddReference (ref : string) (param : CvParam) = 
-        Param.tryAddReference ref param
-
-    static member tryAddUnit (unit : CvUnit) (param : CvParam) = 
-        Param.tryAddUnit unit param
-
     static member getAttributes (param : CvParam) =
         param.Values |> Seq.cast
-
 
     override this.ToString() = 
         $"CvParam: {(this :> ICvBase).Name}\n\tID: {(this :> ICvBase).Accession}\n\tRefUri: {(this :> ICvBase).RefUri}\n\tValue: {(this :> IParamBase).Value}\n\tAttributes: {this.Keys |> Seq.toList}"

--- a/src/ControlledVocabulary/CvParam.fs
+++ b/src/ControlledVocabulary/CvParam.fs
@@ -10,16 +10,16 @@ open FSharpAux
 ///
 /// Attributes can be used to further describe the CvParam
 [<StructuredFormatDisplay("{DisplayText}")>]
-type CvParam(cvAccession : string, cvValue : string, cvRef : string, paramValue : ParamValue, attributes : IDictionary<string,IParam>) =
+type CvParam(cvAccession : string, cvName : string, cvRef : string, paramValue : ParamValue, attributes : IDictionary<string,IParam>) =
 
     inherit CvAttributeCollection(attributes)
 
     interface IParam with 
         member this.Accession   = cvAccession
-        member this.Value       = cvValue
-        member this.RefUri         = cvRef
+        member this.Name        = cvName
+        member this.RefUri      = cvRef
         member this.Value       = paramValue
-        member this.WithValue(v : ParamValue) = CvParam(cvAccession,cvValue,cvRef,v,attributes)
+        member this.WithValue(v : ParamValue) = CvParam(cvAccession,cvName,cvRef,v,attributes)
         member this.HasAttributes 
             with get() = this.Attributes |> Seq.isEmpty |> not
 
@@ -32,7 +32,7 @@ type CvParam(cvAccession : string, cvValue : string, cvRef : string, paramValue 
         CvParam (id,name,ref,ParamValue.Value v)
 
     new (term : CvTerm, pv, attributes : seq<IParam>) = 
-        CvParam (term.Accession, term.Value, term.RefUri, pv, attributes)
+        CvParam (term.Accession, term.Name, term.RefUri, pv, attributes)
     new (cvTerm,pv : ParamValue) = 
         CvParam (cvTerm,pv,Seq.empty)
     new (cvTerm,v : IConvertible) = 
@@ -87,8 +87,8 @@ type CvParam(cvAccession : string, cvValue : string, cvRef : string, paramValue 
     static member tryMapValue (f : ParamValue -> ParamValue option) (param : CvParam) = 
         Param.tryMapValue f param
 
-    static member tryAddValue (value : string) (param : CvParam) = 
-        Param.tryAddValue value param
+    static member tryAddName (value : string) (param : CvParam) = 
+        Param.tryAddName value param
 
     static member tryAddAccession (id : string) (param : CvParam) = 
         Param.tryAddAccession id param
@@ -104,7 +104,7 @@ type CvParam(cvAccession : string, cvValue : string, cvRef : string, paramValue 
 
 
     override this.ToString() = 
-        $"CvParam: {(this :> ICvBase).Value}\n\tID: {(this :> ICvBase).Accession}\n\tRefUri: {(this :> ICvBase).RefUri}\n\tValue: {(this :> IParamBase).Value}\n\tAttributes: {this.Keys |> Seq.toList}"
+        $"CvParam: {(this :> ICvBase).Name}\n\tID: {(this :> ICvBase).Accession}\n\tRefUri: {(this :> ICvBase).RefUri}\n\tValue: {(this :> IParamBase).Value}\n\tAttributes: {this.Keys |> Seq.toList}"
 
     member this.DisplayText = 
         this.ToString()

--- a/src/ControlledVocabulary/CvParam.fs
+++ b/src/ControlledVocabulary/CvParam.fs
@@ -10,16 +10,16 @@ open FSharpAux
 ///
 /// Attributes can be used to further describe the CvParam
 [<StructuredFormatDisplay("{DisplayText}")>]
-type CvParam(cvAccession : string, cvName : string, cvRefUri : string, paramValue : ParamValue, attributes : IDictionary<string,IParam>) =
+type CvParam(cvAccession : string, cvValue : string, cvRef : string, paramValue : ParamValue, attributes : IDictionary<string,IParam>) =
 
     inherit CvAttributeCollection(attributes)
 
     interface IParam with 
-        member this.ID     = cvAccession
-        member this.Name   = cvName
-        member this.RefUri = cvRefUri
-        member this.Value  = paramValue
-        member this.WithValue(v : ParamValue) = CvParam(cvAccession,cvName,cvRefUri,v,attributes)
+        member this.Accession   = cvAccession
+        member this.Value       = cvValue
+        member this.RefUri         = cvRef
+        member this.Value       = paramValue
+        member this.WithValue(v : ParamValue) = CvParam(cvAccession,cvValue,cvRef,v,attributes)
         member this.HasAttributes 
             with get() = this.Attributes |> Seq.isEmpty |> not
 
@@ -31,8 +31,8 @@ type CvParam(cvAccession : string, cvName : string, cvRefUri : string, paramValu
     new (id,name,ref,v : IConvertible) = 
         CvParam (id,name,ref,ParamValue.Value v)
 
-    new ((id,name,ref) : CvTerm,pv,attributes : seq<IParam>) = 
-        CvParam (id,name,ref,pv,attributes)
+    new (term : CvTerm, pv, attributes : seq<IParam>) = 
+        CvParam (term.Accession, term.Value, term.RefUri, pv, attributes)
     new (cvTerm,pv : ParamValue) = 
         CvParam (cvTerm,pv,Seq.empty)
     new (cvTerm,v : IConvertible) = 
@@ -87,11 +87,11 @@ type CvParam(cvAccession : string, cvName : string, cvRefUri : string, paramValu
     static member tryMapValue (f : ParamValue -> ParamValue option) (param : CvParam) = 
         Param.tryMapValue f param
 
-    static member tryAddName (name : string) (param : CvParam) = 
-        Param.tryAddName name param
+    static member tryAddValue (value : string) (param : CvParam) = 
+        Param.tryAddValue value param
 
-    static member tryAddAnnotationID (id : string) (param : CvParam) = 
-        Param.tryAddAnnotationID id param
+    static member tryAddAccession (id : string) (param : CvParam) = 
+        Param.tryAddAccession id param
 
     static member tryAddReference (ref : string) (param : CvParam) = 
         Param.tryAddReference ref param
@@ -104,7 +104,7 @@ type CvParam(cvAccession : string, cvName : string, cvRefUri : string, paramValu
 
 
     override this.ToString() = 
-        $"CvParam: {(this :> ICvBase).Name}\n\tID: {(this :> ICvBase).ID}\n\tRefUri: {(this :> ICvBase).RefUri}\n\tValue: {(this :> IParamBase).Value}\n\tAttributes: {this.Keys |> Seq.toList}"
+        $"CvParam: {(this :> ICvBase).Value}\n\tID: {(this :> ICvBase).Accession}\n\tRefUri: {(this :> ICvBase).RefUri}\n\tValue: {(this :> IParamBase).Value}\n\tAttributes: {this.Keys |> Seq.toList}"
 
     member this.DisplayText = 
         this.ToString()

--- a/src/ControlledVocabulary/CvTerm.fs
+++ b/src/ControlledVocabulary/CvTerm.fs
@@ -1,37 +1,31 @@
 ﻿namespace ControlledVocabulary
 
 /// Represents a term from a controlled vocabulary (Cv)
-/// in the form of: id|accession * name|value * refUri
+/// in the form of: id|accession ; name|value ; refUri
 // ?Maybe [<Struct>]
 //[<Struct>]
-type CvTerm = string * string * string
+type CvTerm = {
+    Accession: string
+    Value: string
+    RefUri: string
+} with
+    static member create(
+        accession: string,
+        value: string,
+        ref : string
+    ) = 
+        {Accession = accession; Value = value; RefUri = ref}
 
-module CvTerm =
-    
-    /// gets the name of the CvTerm
-    let getName (cvTerm : CvTerm) = 
-        match cvTerm with
-        | id, name, refUri -> name
-       
-    /// gets the name of the CvTerm
-    let getId (cvTerm : CvTerm) = 
-        match cvTerm with
-        | id, name, refUri -> id
+    static member create(
+        value: string
+    ) = 
+        CvTerm.create(
+            value = value,
+            accession = "",
+            ref = ""
+        )
 
-    /// gets the source reference of the CvTerm
-    let getRef (cvTerm : CvTerm) = 
-        match cvTerm with
-        | id, name, refUri -> refUri
-
-    /// creates a CvTerm from name
-    let fromName (name : string) : CvTerm= 
-        "", name, ""
-
-    /// creates a CvTerm from a term triplet
-    let create id name ref : CvTerm = 
-        id,name,ref
-        
 /// Represents a unit term from the unit ontology 
 /// in the form of: id|accession * name * refUri
 // ?Maybe [<Struct>]
-type CvUnit = string * string * string
+type CvUnit = CvTerm

--- a/src/ControlledVocabulary/CvTerm.fs
+++ b/src/ControlledVocabulary/CvTerm.fs
@@ -6,21 +6,21 @@
 //[<Struct>]
 type CvTerm = {
     Accession: string
-    Value: string
+    Name: string
     RefUri: string
 } with
     static member create(
         accession: string,
-        value: string,
+        name: string,
         ref : string
     ) = 
-        {Accession = accession; Value = value; RefUri = ref}
+        {Accession = accession; Name = name; RefUri = ref}
 
     static member create(
-        value: string
+        name: string
     ) = 
         CvTerm.create(
-            value = value,
+            name = name,
             accession = "",
             ref = ""
         )

--- a/src/ControlledVocabulary/ICvBase.fs
+++ b/src/ControlledVocabulary/ICvBase.fs
@@ -8,9 +8,9 @@ type IAttributeCollection =
 
 /// Interface ensures the propterties necessary for CvTerm 
 and ICvBase =
-    abstract member ID       : string
-    abstract member Name     : string
-    abstract member RefUri   : string
+    abstract member Accession   : string
+    abstract member Value       : string
+    abstract member RefUri         : string
     
     inherit IAttributeCollection
 
@@ -21,11 +21,11 @@ module CvBase =
     
     /// Returns the id of the cv item
     let getCvAccession (cv : #ICvBase) =
-        cv.ID
+        cv.Accession
 
     /// Returns the name of the cv item
-    let getCvName (cv : #ICvBase) =
-        cv.Name
+    let getCvValue (cv : #ICvBase) =
+        cv.Value
 
     /// Returns the reference of the cv item
     let getCvRef (cv : #ICvBase) =
@@ -33,7 +33,7 @@ module CvBase =
 
     /// Returns the full term of the cv item
     let getTerm (cv : #ICvBase) : CvTerm =
-        CvTerm.create cv.ID cv.Name cv.RefUri
+        CvTerm.create(accession = cv.Accession, value = cv.Value, ref = cv.RefUri)
 
     /// Returns true, if the given term matches the term of the cv item
     let equalsTerm (term : CvTerm) (cv : #ICvBase) =
@@ -44,8 +44,8 @@ module CvBase =
         getTerm cv1 = getTerm cv2
 
     /// Returns true, if the names of the given cv items match
-    let equalsName (cv1 : #ICvBase) (cv2 : #ICvBase) =
-        getCvName cv1 = getCvName cv2
+    let equalsValue (cv1 : #ICvBase) (cv2 : #ICvBase) =
+        getCvValue cv1 = getCvValue cv2
 
     /// Returns Some Value of type 'T, if the given cv item can be downcast, else returns None
     let inline tryAs<'T when 'T :> ICvBase> (cv : ICvBase) =

--- a/src/ControlledVocabulary/ICvBase.fs
+++ b/src/ControlledVocabulary/ICvBase.fs
@@ -17,44 +17,44 @@ and ICvBase =
     //override this.ToString() = 
     //    $"Name: {this.Name}\nID: {this.ID}\nRefUri: {this.RefUri}"
 
-module CvBase = 
+type CvBase = 
     
     /// Returns the id of the cv item
-    let getCvAccession (cv : #ICvBase) =
+    static member getCvAccession (cv : #ICvBase) =
         cv.Accession
 
     /// Returns the name of the cv item
-    let getCvName (cv : #ICvBase) =
+    static member getCvName (cv : #ICvBase) =
         cv.Name
 
     /// Returns the reference of the cv item
-    let getCvRef (cv : #ICvBase) =
+    static member getCvRef (cv : #ICvBase) =
         cv.RefUri
 
     /// Returns the full term of the cv item
-    let getTerm (cv : #ICvBase) : CvTerm =
+    static member getTerm (cv : #ICvBase) : CvTerm =
         CvTerm.create(accession = cv.Accession, name = cv.Name, ref = cv.RefUri)
 
     /// Returns true, if the given term matches the term of the cv item
-    let equalsTerm (term : CvTerm) (cv : #ICvBase) =
-        getTerm cv = term
+    static member equalsTerm (term : CvTerm) (cv : #ICvBase) =
+        CvBase.getTerm cv = term
 
     /// Returns true, if the terms of the given cv items match
-    let equals (cv1 : #ICvBase) (cv2 : #ICvBase) =
-        getTerm cv1 = getTerm cv2
+    static member equals (cv1 : #ICvBase) (cv2 : #ICvBase) =
+        CvBase.getTerm cv1 = CvBase.getTerm cv2
 
     /// Returns true, if the names of the given cv items match
-    let equalsName (cv1 : #ICvBase) (cv2 : #ICvBase) =
-        getCvName cv1 = getCvName cv2
+    static member equalsName (cv1 : #ICvBase) (cv2 : #ICvBase) =
+        CvBase.getCvName cv1 = CvBase.getCvName cv2
 
     /// Returns Some Value of type 'T, if the given cv item can be downcast, else returns None
-    let inline tryAs<'T when 'T :> ICvBase> (cv : ICvBase) =
+    static member inline tryAs<'T when 'T :> ICvBase> (cv : ICvBase) =
         match cv with
         | :? 'T as cv -> Some cv
         | _ -> None
 
     /// Returns true, if the given cv item can be downcast
-    let inline is<'T when 'T :> ICvBase> (cv : ICvBase) =
+    static member inline is<'T when 'T :> ICvBase> (cv : ICvBase) =
         match cv with
         | :? 'T as cv -> true
         | _ -> false

--- a/src/ControlledVocabulary/ICvBase.fs
+++ b/src/ControlledVocabulary/ICvBase.fs
@@ -9,8 +9,8 @@ type IAttributeCollection =
 /// Interface ensures the propterties necessary for CvTerm 
 and ICvBase =
     abstract member Accession   : string
-    abstract member Value       : string
-    abstract member RefUri         : string
+    abstract member Name        : string
+    abstract member RefUri      : string
     
     inherit IAttributeCollection
 
@@ -24,8 +24,8 @@ module CvBase =
         cv.Accession
 
     /// Returns the name of the cv item
-    let getCvValue (cv : #ICvBase) =
-        cv.Value
+    let getCvName (cv : #ICvBase) =
+        cv.Name
 
     /// Returns the reference of the cv item
     let getCvRef (cv : #ICvBase) =
@@ -33,7 +33,7 @@ module CvBase =
 
     /// Returns the full term of the cv item
     let getTerm (cv : #ICvBase) : CvTerm =
-        CvTerm.create(accession = cv.Accession, value = cv.Value, ref = cv.RefUri)
+        CvTerm.create(accession = cv.Accession, name = cv.Name, ref = cv.RefUri)
 
     /// Returns true, if the given term matches the term of the cv item
     let equalsTerm (term : CvTerm) (cv : #ICvBase) =
@@ -44,8 +44,8 @@ module CvBase =
         getTerm cv1 = getTerm cv2
 
     /// Returns true, if the names of the given cv items match
-    let equalsValue (cv1 : #ICvBase) (cv2 : #ICvBase) =
-        getCvValue cv1 = getCvValue cv2
+    let equalsName (cv1 : #ICvBase) (cv2 : #ICvBase) =
+        getCvName cv1 = getCvName cv2
 
     /// Returns Some Value of type 'T, if the given cv item can be downcast, else returns None
     let inline tryAs<'T when 'T :> ICvBase> (cv : ICvBase) =

--- a/src/ControlledVocabulary/IParam.fs
+++ b/src/ControlledVocabulary/IParam.fs
@@ -21,8 +21,8 @@ type Param =
         CvBase.equals param1 param2
 
     /// Returns true, if the value of the given params match
-    static member equalsValue (param1 : IParam) (param2 : IParam) =
-        CvBase.equalsValue param1 param2
+    static member equalsName (param1 : IParam) (param2 : IParam) =
+        CvBase.equalsName param1 param2
 
     /// Returns Some Param, if the given cv item can be downcast, else returns None
     static member tryParam (cv : ICvBase) =
@@ -78,8 +78,8 @@ type Param =
     static member tryMapValue (f : ParamValue -> ParamValue option) (param : IParam) = 
         ParamBase.tryMapValue f param |> Option.map (fun v -> v :?> IParam)
 
-    static member tryAddValue (value : string) (param : IParam) = 
-        ParamBase.tryAddValue value param |> Option.map (fun v -> v :?> IParam)
+    static member tryAddName (value : string) (param : IParam) = 
+        ParamBase.tryAddName value param |> Option.map (fun v -> v :?> IParam)
 
     static member tryAddAccession (id : string) (param : IParam) = 
         ParamBase.tryAddAccession id param |> Option.map (fun v -> v :?> IParam)

--- a/src/ControlledVocabulary/IParam.fs
+++ b/src/ControlledVocabulary/IParam.fs
@@ -9,7 +9,6 @@ type IParam =
     inherit ICvBase
     inherit IParamBase
 
-
 type Param =
 
     /// Returns true, if the given term matches the term of the param
@@ -89,4 +88,4 @@ type Param =
 
     static member tryAddUnit (unit : CvUnit) (param : IParam) = 
         ParamBase.tryAddUnit unit param |> Option.map (fun v -> v :?> IParam)
-// TO DO: create-Funktionen in UserParam und CvParam sollen IParam zurückgeben statt ihren eigenen Typ
+

--- a/src/ControlledVocabulary/IParam.fs
+++ b/src/ControlledVocabulary/IParam.fs
@@ -55,7 +55,6 @@ type Param =
     static member getValue (param:IParamBase) =
         param |> ParamBase.getValue
 
-
     /// Returns the value of the param as a string.
     static member getValueAsString (cvParam : IParam) =
         (cvParam :> IParamBase).Value

--- a/src/ControlledVocabulary/IParam.fs
+++ b/src/ControlledVocabulary/IParam.fs
@@ -11,80 +11,102 @@ type IParam =
 
 type Param =
 
-    /// Returns true, if the given term matches the term of the param
-    static member equalsTerm (term : CvTerm) (param : IParam) =
-        CvBase.equalsTerm term param
+    //---------------------- IParamBase implementations ----------------------//
 
-    /// Returns true, if the terms of the given params match
-    static member equals (param1 : IParam) (param2 : IParam) =
-        CvBase.equals param1 param2
+    /// Returns the value of the Param as a ParamValue
+    static member getParamValue (param: IParam) = ParamBase.getParamValue param
 
-    /// Returns true, if the value of the given params match
-    static member equalsName (param1 : IParam) (param2 : IParam) =
-        CvBase.equalsName param1 param2
+    /// Returns the value of the Param as IConvertible
+    static member getValue (param: IParam) = ParamBase.getValue param
 
-    /// Returns Some Param, if the given cv item can be downcast, else returns None
-    static member tryParam (cv : ICvBase) =
-        match cv with
-        | :? IParam as param -> Some param
-        | _ -> None
+    /// Returns the value of the Param as string
+    static member getValueAsString (param: IParam) = ParamBase.getValueAsString param
+        
+    /// Returns the value of the Param as int if possible, else fails
+    static member getValueAsInt (param: IParam) = ParamBase.getValueAsInt param
 
-    /// Returns Some Param, if the given value item can be downcast, else returns None
-    static member tryParam (cv : IParamBase) =
-        match cv with
-        | :? IParam as param -> Some param
-        | _ -> None
+    /// Returns the value of the Param as a term
+    static member getValueAsTerm (param: IParam) = ParamBase.getValueAsTerm param
 
-    /// Returns Some Value of type 'T, if the given param can be downcast, else returns None
-    static member inline tryAs<'T when 'T :> IParam> (cv : IParam) =
-        match cv with
-        | :? 'T as cv -> Some cv
-        | _ -> None
+    static member tryGetValueAccession (param: IParam) = ParamBase.tryGetValueAccession param
 
-    /// Returns true, if the given param can be downcast
-    static member inline is<'T when 'T :> IParam> (cv : IParam) =
-        match cv with
-        | :? 'T as cv -> true
-        | _ -> false
+    static member tryGetValueRef (param: IParam) = ParamBase.tryGetValueRef param
 
-    /// Returns the typed value of the param.
-    static member getParamValue (param : IParam) =
-        param |> ParamBase.getParamValue
+    static member tryGetCvUnit (param: IParam) : CvUnit option = ParamBase.tryGetCvUnit param
 
-    /// Returns the value of the Param as a IConvertiböe
-    static member getValue (param:IParamBase) =
-        param |> ParamBase.getValue
+    static member tryGetCvUnitValue (param: IParam) = ParamBase.tryGetCvUnitValue param
 
-    /// Returns the value of the param as a string.
-    static member getValueAsString (cvParam : IParam) =
-        (cvParam :> IParamBase).Value
-        |> ParamValue.getValueAsString
+    static member tryGetCvUnitTermName (param: IParam) = ParamBase.tryGetCvUnitTermName param
 
-    /// Returns the value of the param as an int if possible, else fails.
-    static member getValueAsInt (cvParam : IParam) =
-        (cvParam :> IParamBase).Value
-        |> ParamValue.getValueAsInt
+    static member tryGetCvUnitTermAccession (param: IParam) = ParamBase.tryGetCvUnitTermAccession param
 
-    /// Returns the value of the param as a CvTerm.
-    static member getValueAsTerm (cvParam : IParam) =
-        (cvParam :> IParamBase).Value
-        |> ParamValue.getValueAsTerm
+    static member tryGetCvUnitTermRef (param: IParam) = ParamBase.tryGetCvUnitTermRef param
 
-    static member mapValue (f : ParamValue -> ParamValue) (param : IParam) = 
-        ParamBase.mapValue f param :?> IParam
+    static member mapValue (f : ParamValue -> ParamValue) (param : IParam) = ParamBase.mapValue f param :?> IParam
 
-    static member tryMapValue (f : ParamValue -> ParamValue option) (param : IParam) = 
-        ParamBase.tryMapValue f param |> Option.map (fun v -> v :?> IParam)
+    static member tryMapValue (f : ParamValue -> ParamValue option) (param : IParamBase) = 
+        ParamBase.tryMapValue f param 
+        |> Option.map (fun v -> v :?> IParam)
 
-    static member tryAddName (value : string) (param : IParam) = 
-        ParamBase.tryAddName value param |> Option.map (fun v -> v :?> IParam)
+    static member tryAddName (name : string) (param : IParamBase) = 
+        ParamBase.tryAddName name param
+        |> Option.map (fun v -> v :?> IParam)
 
-    static member tryAddAccession (id : string) (param : IParam) = 
-        ParamBase.tryAddAccession id param |> Option.map (fun v -> v :?> IParam)
+    static member tryAddAccession (acc : string) (param : IParamBase) = 
+        ParamBase.tryAddAccession acc param
+        |> Option.map (fun v -> v :?> IParam)
 
-    static member tryAddReference (ref : string) (param : IParam) = 
-        ParamBase.tryAddReference ref param |> Option.map (fun v -> v :?> IParam)
+    static member tryAddReference (ref : string) (param : IParamBase) = 
+        ParamBase.tryAddReference ref param
+        |> Option.map (fun v -> v :?> IParam)
 
-    static member tryAddUnit (unit : CvUnit) (param : IParam) = 
-        ParamBase.tryAddUnit unit param |> Option.map (fun v -> v :?> IParam)
+    static member tryAddUnit (unit : CvUnit) (param : IParamBase) = 
+        ParamBase.tryAddUnit unit param
+        |> Option.map (fun v -> v :?> IParam)
 
+    //------------------------ ICvBase implementations -----------------------//
+    
+    /// Returns the id of the cv item
+    static member getCvAccession (param: IParam) = CvBase.getCvAccession param
+
+    /// Returns the name of the cv item
+    static member getCvName (param: IParam) = CvBase.getCvName param
+
+    /// Returns the reference of the cv item
+    static member getCvRef (param: IParam) = CvBase.getCvRef param
+
+    /// Returns the full term of the cv item
+    static member getTerm (param: IParam) = CvBase.getTerm param
+
+    /// Returns true, if the given term matches the term of the cv item
+    static member equalsTerm (term : CvTerm) (param: IParam) = CvBase.equalsTerm term param
+
+    /// Returns true, if the terms of the given param items match
+    static member equals (param1 : IParam) (param2 : IParam) = CvBase.equals param1 param2
+
+    /// Returns true, if the names of the given param items match
+    static member equalsName (param1 : IParam) (param2 : IParam) = CvBase.equalsName param1 param2
+
+    /// Returns Some Value of type 'T, if the given param item can be downcast, else returns None
+    static member inline tryAs<'T when 'T :> IParam> (param: IParam) = CvBase.tryAs<'T> param
+
+    /// Returns true, if the given param item can be downcast
+    static member inline is<'T when 'T :> IParam> (param : IParam) = CvBase.is<'T> param
+
+    //-------------------- IParam specific implementations -------------------//
+
+
+module IParamExtensions =
+    type CvBase with
+        /// Returns Some Param, if the given param item can be downcast, else returns None
+        static member tryParam (cv : ICvBase) =
+            match cv with
+            | :? IParam as param -> Some param
+            | _ -> None
+
+    type ParamBase with
+        /// Returns Some Param, if the given value item can be downcast, else returns None
+        static member tryParam (cv : IParamBase) =
+            match cv with
+            | :? IParam as param -> Some param
+            | _ -> None

--- a/src/ControlledVocabulary/IParam.fs
+++ b/src/ControlledVocabulary/IParam.fs
@@ -20,9 +20,9 @@ type Param =
     static member equals (param1 : IParam) (param2 : IParam) =
         CvBase.equals param1 param2
 
-    /// Returns true, if the name of the given params match
-    static member equalsName (param1 : IParam) (param2 : IParam) =
-        CvBase.equalsName param1 param2
+    /// Returns true, if the value of the given params match
+    static member equalsValue (param1 : IParam) (param2 : IParam) =
+        CvBase.equalsValue param1 param2
 
     /// Returns Some Param, if the given cv item can be downcast, else returns None
     static member tryParam (cv : ICvBase) =
@@ -78,11 +78,11 @@ type Param =
     static member tryMapValue (f : ParamValue -> ParamValue option) (param : IParam) = 
         ParamBase.tryMapValue f param |> Option.map (fun v -> v :?> IParam)
 
-    static member tryAddName (name : string) (param : IParam) = 
-        ParamBase.tryAddName name param |> Option.map (fun v -> v :?> IParam)
+    static member tryAddValue (value : string) (param : IParam) = 
+        ParamBase.tryAddValue value param |> Option.map (fun v -> v :?> IParam)
 
-    static member tryAddAnnotationID (id : string) (param : IParam) = 
-        ParamBase.tryAddAnnotationID id param |> Option.map (fun v -> v :?> IParam)
+    static member tryAddAccession (id : string) (param : IParam) = 
+        ParamBase.tryAddAccession id param |> Option.map (fun v -> v :?> IParam)
 
     static member tryAddReference (ref : string) (param : IParam) = 
         ParamBase.tryAddReference ref param |> Option.map (fun v -> v :?> IParam)

--- a/src/ControlledVocabulary/IParam.fs
+++ b/src/ControlledVocabulary/IParam.fs
@@ -96,6 +96,7 @@ type Param =
     //-------------------- IParam specific implementations -------------------//
 
 
+[<AutoOpen>]
 module IParamExtensions =
     type CvBase with
         /// Returns Some Param, if the given param item can be downcast, else returns None

--- a/src/ControlledVocabulary/IParamBase.fs
+++ b/src/ControlledVocabulary/IParamBase.fs
@@ -54,11 +54,11 @@ module ParamBase =
         | CvValue                _  -> None
         | WithCvUnitAccession (v,_) -> Some v
 
-    let tryGetCvUnitTermValue (param : #IParamBase) =
+    let tryGetCvUnitTermName (param : #IParamBase) =
         match param.Value with
         | Value                  _          -> None
         | CvValue                _          -> None
-        | WithCvUnitAccession   (_,cvu)     -> Some cvu.Value
+        | WithCvUnitAccession   (_,cvu)     -> Some cvu.Name
 
     let tryGetCvUnitTermAccession (param : #IParamBase) =
         match param.Value with
@@ -81,8 +81,8 @@ module ParamBase =
             Some (param.WithValue(value))
         | None -> None
 
-    let tryAddValue (value : string) (param : IParamBase) = 
-        tryMapValue (ParamValue.tryAddValue value) param
+    let tryAddName (value : string) (param : IParamBase) = 
+        tryMapValue (ParamValue.tryAddName value) param
 
     let tryAddAccession (acc : string) (param : IParamBase) = 
         tryMapValue (ParamValue.tryAddAccession acc) param

--- a/src/ControlledVocabulary/IParamBase.fs
+++ b/src/ControlledVocabulary/IParamBase.fs
@@ -31,14 +31,14 @@ module ParamBase =
 
     let tryGetValueAccession (param : #IParamBase) =
         match param.Value with
-        | CvValue                   (a,_,_) -> Some a
+        | CvValue                   cv      -> Some cv.Accession
         | Value                      _      -> None     // mere Value has no accession number
         | WithCvUnitAccession        _      -> None     // use tryGetCvUnitAccession instead
         //| WithCvUnitAccession (_,(a,_,_))   -> Some a
 
     let tryGetValueRef (param : #IParamBase) =
         match param.Value with
-        | CvValue               (_,_,r) -> Some r
+        | CvValue                    cv -> Some cv.RefUri
         | Value                      _  -> None     // mere Value has no ref
         | WithCvUnitAccession        _  -> None     // use tryGetCvUnitRef instead
 
@@ -54,23 +54,23 @@ module ParamBase =
         | CvValue                _  -> None
         | WithCvUnitAccession (v,_) -> Some v
 
-    let tryGetCvUnitName (param : #IParamBase) =
+    let tryGetCvUnitTermValue (param : #IParamBase) =
         match param.Value with
         | Value                  _          -> None
         | CvValue                _          -> None
-        | WithCvUnitAccession   (_,(_,n,_)) -> Some n
+        | WithCvUnitAccession   (_,cvu)     -> Some cvu.Value
 
-    let tryGetCvUnitAccession (param : #IParamBase) =
+    let tryGetCvUnitTermAccession (param : #IParamBase) =
         match param.Value with
         | Value                  _          -> None
         | CvValue                _          -> None
-        | WithCvUnitAccession   (_,(a,_,_)) -> Some a
+        | WithCvUnitAccession   (_,cvu)     -> Some cvu.Accession
 
-    let tryGetCvUnitRef (param : #IParamBase) =
+    let tryGetCvUnitTermRef (param : #IParamBase) =
         match param.Value with
         | Value                  _          -> None
         | CvValue                _          -> None
-        | WithCvUnitAccession   (_,(_,_,r)) -> Some r
+        | WithCvUnitAccession   (_,cvu)     -> Some cvu.RefUri
 
     let mapValue (f : ParamValue -> ParamValue) (param : IParamBase) = 
         param.WithValue(f param.Value)
@@ -81,11 +81,11 @@ module ParamBase =
             Some (param.WithValue(value))
         | None -> None
 
-    let tryAddName (name : string) (param : IParamBase) = 
-        tryMapValue (ParamValue.tryAddName name) param
+    let tryAddValue (value : string) (param : IParamBase) = 
+        tryMapValue (ParamValue.tryAddValue value) param
 
-    let tryAddAnnotationID (id : string) (param : IParamBase) = 
-        tryMapValue (ParamValue.tryAddAnnotationID id) param
+    let tryAddAccession (acc : string) (param : IParamBase) = 
+        tryMapValue (ParamValue.tryAddAccession acc) param
 
     let tryAddReference (ref : string) (param : IParamBase) = 
         tryMapValue (ParamValue.tryAddReference ref) param

--- a/src/ControlledVocabulary/IParamBase.fs
+++ b/src/ControlledVocabulary/IParamBase.fs
@@ -7,88 +7,88 @@ type IParamBase =
     abstract member Value : ParamValue
     abstract member WithValue : ParamValue -> IParamBase
 
-module ParamBase = 
+type ParamBase = 
 
     /// Returns the value of the Param as a ParamValue
-    let getParamValue (param:IParamBase) =
+    static member getParamValue (param:IParamBase) =
         param.Value
 
     /// Returns the value of the Param as IConvertible
-    let getValue (param:IParamBase) =
+    static member getValue (param:IParamBase) =
         ParamValue.getValue param.Value
 
     /// Returns the value of the Param as string
-    let getValueAsString (param:IParamBase) =
+    static member getValueAsString (param:IParamBase) =
         ParamValue.getValueAsString param.Value
         
     /// Returns the value of the Param as int if possible, else fails
-    let getValueAsInt (param:IParamBase) =
+    static member getValueAsInt (param:IParamBase) =
         ParamValue.getValueAsInt param.Value
 
     /// Returns the value of the Param as a term
-    let getValueAsTerm (param:IParamBase) =
+    static member getValueAsTerm (param:IParamBase) =
         ParamValue.getValueAsTerm param.Value
 
-    let tryGetValueAccession (param : #IParamBase) =
+    static member tryGetValueAccession (param : #IParamBase) =
         match param.Value with
         | CvValue                   cv      -> Some cv.Accession
         | Value                      _      -> None     // mere Value has no accession number
         | WithCvUnitAccession        _      -> None     // use tryGetCvUnitAccession instead
         //| WithCvUnitAccession (_,(a,_,_))   -> Some a
 
-    let tryGetValueRef (param : #IParamBase) =
+    static member tryGetValueRef (param : #IParamBase) =
         match param.Value with
         | CvValue                    cv -> Some cv.RefUri
         | Value                      _  -> None     // mere Value has no ref
         | WithCvUnitAccession        _  -> None     // use tryGetCvUnitRef instead
 
-    let tryGetCvUnit (param : #IParamBase) : CvUnit option =
+    static member tryGetCvUnit (param : #IParamBase) : CvUnit option =
         match param.Value with
         | Value                  _  -> None
         | CvValue                _  -> None
         | WithCvUnitAccession (_,u) -> Some u
 
-    let tryGetCvUnitValue (param : #IParamBase) : #IConvertible option =
+    static member tryGetCvUnitValue (param : #IParamBase) : #IConvertible option =
         match param.Value with
         | Value                  _  -> None
         | CvValue                _  -> None
         | WithCvUnitAccession (v,_) -> Some v
 
-    let tryGetCvUnitTermName (param : #IParamBase) =
+    static member tryGetCvUnitTermName (param : #IParamBase) =
         match param.Value with
         | Value                  _          -> None
         | CvValue                _          -> None
         | WithCvUnitAccession   (_,cvu)     -> Some cvu.Name
 
-    let tryGetCvUnitTermAccession (param : #IParamBase) =
+    static member tryGetCvUnitTermAccession (param : #IParamBase) =
         match param.Value with
         | Value                  _          -> None
         | CvValue                _          -> None
         | WithCvUnitAccession   (_,cvu)     -> Some cvu.Accession
 
-    let tryGetCvUnitTermRef (param : #IParamBase) =
+    static member tryGetCvUnitTermRef (param : #IParamBase) =
         match param.Value with
         | Value                  _          -> None
         | CvValue                _          -> None
         | WithCvUnitAccession   (_,cvu)     -> Some cvu.RefUri
 
-    let mapValue (f : ParamValue -> ParamValue) (param : IParamBase) = 
+    static member mapValue (f : ParamValue -> ParamValue) (param : IParamBase) = 
         param.WithValue(f param.Value)
 
-    let tryMapValue (f : ParamValue -> ParamValue option) (param : IParamBase) = 
+    static member tryMapValue (f : ParamValue -> ParamValue option) (param : IParamBase) = 
         match f param.Value with
         | Some value -> 
             Some (param.WithValue(value))
         | None -> None
 
-    let tryAddName (value : string) (param : IParamBase) = 
-        tryMapValue (ParamValue.tryAddName value) param
+    static member tryAddName (value : string) (param : IParamBase) = 
+        ParamBase.tryMapValue (ParamValue.tryAddName value) param
 
-    let tryAddAccession (acc : string) (param : IParamBase) = 
-        tryMapValue (ParamValue.tryAddAccession acc) param
+    static member tryAddAccession (acc : string) (param : IParamBase) = 
+        ParamBase.tryMapValue (ParamValue.tryAddAccession acc) param
 
-    let tryAddReference (ref : string) (param : IParamBase) = 
-        tryMapValue (ParamValue.tryAddReference ref) param
+    static member tryAddReference (ref : string) (param : IParamBase) = 
+        ParamBase.tryMapValue (ParamValue.tryAddReference ref) param
 
-    let tryAddUnit (unit : CvUnit) (param : IParamBase) = 
-        tryMapValue (ParamValue.tryAddUnit unit) param
+    static member tryAddUnit (unit : CvUnit) (param : IParamBase) = 
+        ParamBase.tryMapValue (ParamValue.tryAddUnit unit) param

--- a/src/ControlledVocabulary/ParamValue.fs
+++ b/src/ControlledVocabulary/ParamValue.fs
@@ -12,39 +12,33 @@ type ParamValue =
     // value * CvUnit
     | WithCvUnitAccession of cvu : IConvertible * CvUnit
 
-    //static member getValueAsStringWithUnit (param:ParamValue) =
-    //    match param with
-    //    | Value   v                 -> string v
-    //    | CvValue (_,v,_)           -> v
-    //    | WithCvUnitAccession (v,_) -> string v
-
     /// Returns the value of the Param as IConvertible
     static member getValue (param:ParamValue) =
         match param with
         | Value   v                 -> v
-        | CvValue (_,v,_)           -> v :> IConvertible
+        | CvValue cv                -> cv.Value :> IConvertible
         | WithCvUnitAccession (v,_) -> v
 
     /// Returns the value of the Param as string
     static member getValueAsString (param:ParamValue) =
         match param with
         | Value   v                 -> string v
-        | CvValue (_,v,_)           -> v
+        | CvValue cv                -> cv.Value
         | WithCvUnitAccession (v,_) -> string v
         
     /// Returns the value of the Param as int if possible, else fails
     static member getValueAsInt (param:ParamValue) =
         match param with
         | Value   v                 -> v :?> int
-        | CvValue (_,v,_)           -> v |> int
+        | CvValue cv                -> cv.Value |> int
         | WithCvUnitAccession (v,_) -> v :?> int
 
     /// Returns the value of the Param as a term
     static member getValueAsTerm (param:ParamValue) =
         match param with
-        | Value   v              -> CvTerm.fromName (v |> string)
-        | CvValue term           -> term
-        | WithCvUnitAccession (v,_) -> CvTerm.fromName (v |> string)
+        | Value   v                 -> CvTerm.create(value = (v |> string))
+        | CvValue term              -> term
+        | WithCvUnitAccession (v,_) -> CvTerm.create(value = (v |> string))
 
     /// Returns the unit of the Param if it exists, else returns None
     static member tryGetUnit  (param:ParamValue) : CvUnit option =
@@ -54,30 +48,30 @@ type ParamValue =
         | WithCvUnitAccession (_,u) -> Some u
 
     /// Returns a new paramValue with the given name if possible, else returns None
-    static member tryAddName (name : string) (param : ParamValue) = 
+    static member tryAddValue (value : string) (param : ParamValue) = 
         match param with
-        | Value v                   -> Some (Value name)
-        | CvValue (id,"",ref)       -> Some (CvValue (id,name,ref))
-        | CvValue term              -> None
-        | WithCvUnitAccession (_,u) -> None
+        | Value v                       -> Some (Value value)
+        | CvValue cv when cv.Value = "" -> Some (CvValue {cv with Value = value})
+        | CvValue term                  -> None
+        | WithCvUnitAccession (_,u)     -> None
         
     /// Returns a new paramValue with the given annotationID if possible, else returns None
-    static member tryAddAnnotationID (id : string) (param : ParamValue) = 
+    static member tryAddAccession (accession : string) (param : ParamValue) = 
         match param with
-        | Value (:? string as v)    -> Some (CvValue (id,v,""))
-        | Value v                   -> None
-        | CvValue ("",name,ref)     -> Some (CvValue (id,name,ref))
-        | CvValue term              -> None
-        | WithCvUnitAccession (_,u) -> None
+        | Value (:? string as v)            -> Some (CvValue (CvTerm.create(accession = accession, value = v, ref = "")))
+        | Value v                           -> None
+        | CvValue cv when cv.Accession = "" -> Some (CvValue {cv with Accession = accession})
+        | CvValue term                      -> None
+        | WithCvUnitAccession (_,u)         -> None
 
     /// Returns a new paramValue with the given reference if possible, else returns None
     static member tryAddReference (ref : string) (param : ParamValue) = 
         match param with
-        | Value (:? string as v)    -> Some (CvValue ("",v,ref))
-        | Value v                   -> None
-        | CvValue (id,name,"")     -> Some (CvValue (id,name,ref))
-        | CvValue term              -> None
-        | WithCvUnitAccession (_,u) -> None
+        | Value (:? string as v)        -> Some (CvValue (CvTerm.create(accession = "", value = v, ref = ref)))
+        | Value v                       -> None
+        | CvValue cv when cv.RefUri = ""   -> Some (CvValue {cv with RefUri = ref})
+        | CvValue term                  -> None
+        | WithCvUnitAccession (_,u)     -> None
 
     /// Returns a new paramValue with the given unit if possible, else returns None
     static member tryAddUnit (unit : CvUnit) (param : ParamValue) = 

--- a/src/ControlledVocabulary/ParamValue.fs
+++ b/src/ControlledVocabulary/ParamValue.fs
@@ -16,29 +16,29 @@ type ParamValue =
     static member getValue (param:ParamValue) =
         match param with
         | Value   v                 -> v
-        | CvValue cv                -> cv.Value :> IConvertible
+        | CvValue cv                -> cv.Name :> IConvertible
         | WithCvUnitAccession (v,_) -> v
 
     /// Returns the value of the Param as string
     static member getValueAsString (param:ParamValue) =
         match param with
         | Value   v                 -> string v
-        | CvValue cv                -> cv.Value
+        | CvValue cv                -> cv.Name
         | WithCvUnitAccession (v,_) -> string v
         
     /// Returns the value of the Param as int if possible, else fails
     static member getValueAsInt (param:ParamValue) =
         match param with
         | Value   v                 -> v :?> int
-        | CvValue cv                -> cv.Value |> int
+        | CvValue cv                -> cv.Name |> int
         | WithCvUnitAccession (v,_) -> v :?> int
 
     /// Returns the value of the Param as a term
     static member getValueAsTerm (param:ParamValue) =
         match param with
-        | Value   v                 -> CvTerm.create(value = (v |> string))
+        | Value   v                 -> CvTerm.create(name = (v |> string))
         | CvValue term              -> term
-        | WithCvUnitAccession (v,_) -> CvTerm.create(value = (v |> string))
+        | WithCvUnitAccession (v,_) -> CvTerm.create(name = (v |> string))
 
     /// Returns the unit of the Param if it exists, else returns None
     static member tryGetUnit  (param:ParamValue) : CvUnit option =
@@ -48,17 +48,17 @@ type ParamValue =
         | WithCvUnitAccession (_,u) -> Some u
 
     /// Returns a new paramValue with the given name if possible, else returns None
-    static member tryAddValue (value : string) (param : ParamValue) = 
+    static member tryAddName (name : string) (param : ParamValue) = 
         match param with
-        | Value v                       -> Some (Value value)
-        | CvValue cv when cv.Value = "" -> Some (CvValue {cv with Value = value})
+        | Value v                       -> Some (Value name)
+        | CvValue cv when cv.Name = ""  -> Some (CvValue {cv with Name = name})
         | CvValue term                  -> None
         | WithCvUnitAccession (_,u)     -> None
         
     /// Returns a new paramValue with the given annotationID if possible, else returns None
     static member tryAddAccession (accession : string) (param : ParamValue) = 
         match param with
-        | Value (:? string as v)            -> Some (CvValue (CvTerm.create(accession = accession, value = v, ref = "")))
+        | Value (:? string as v)            -> Some (CvValue (CvTerm.create(accession = accession, name = v, ref = "")))
         | Value v                           -> None
         | CvValue cv when cv.Accession = "" -> Some (CvValue {cv with Accession = accession})
         | CvValue term                      -> None
@@ -67,7 +67,7 @@ type ParamValue =
     /// Returns a new paramValue with the given reference if possible, else returns None
     static member tryAddReference (ref : string) (param : ParamValue) = 
         match param with
-        | Value (:? string as v)        -> Some (CvValue (CvTerm.create(accession = "", value = v, ref = ref)))
+        | Value (:? string as v)        -> Some (CvValue (CvTerm.create(accession = "", name = v, ref = ref)))
         | Value v                       -> None
         | CvValue cv when cv.RefUri = ""   -> Some (CvValue {cv with RefUri = ref})
         | CvValue term                  -> None

--- a/src/ControlledVocabulary/UserParam.fs
+++ b/src/ControlledVocabulary/UserParam.fs
@@ -10,9 +10,9 @@ type UserParam(name : string, paramValue : ParamValue, attributes : IDictionary<
     inherit CvAttributeCollection(attributes)        
 
     interface IParam with 
-        member this.ID     = name
-        member this.Name   = name
-        member this.RefUri = "UserTerm"
+        member this.Accession   = name
+        member this.Value       = name
+        member this.RefUri         = "UserTerm"
         member this.Value  = paramValue
         member this.WithValue(v : ParamValue) = UserParam(name,v,attributes)
         member this.HasAttributes 
@@ -43,7 +43,7 @@ type UserParam(name : string, paramValue : ParamValue, attributes : IDictionary<
         | _ -> None
 
     override this.ToString() = 
-        $"Name: {(this :> ICvBase).Name}\n\tValue: {(this :> IParamBase).Value}\n\tQualifiers: {this.Keys |> Seq.toList}"
+        $"Name: {(this :> ICvBase).Value}\n\tValue: {(this :> IParamBase).Value}\n\tQualifiers: {this.Keys |> Seq.toList}"
 
     member this.DisplayText = 
         this.ToString()

--- a/src/ControlledVocabulary/UserParam.fs
+++ b/src/ControlledVocabulary/UserParam.fs
@@ -11,8 +11,8 @@ type UserParam(name : string, paramValue : ParamValue, attributes : IDictionary<
 
     interface IParam with 
         member this.Accession   = name
-        member this.Value       = name
-        member this.RefUri         = "UserTerm"
+        member this.Name        = name
+        member this.RefUri      = "UserTerm"
         member this.Value  = paramValue
         member this.WithValue(v : ParamValue) = UserParam(name,v,attributes)
         member this.HasAttributes 
@@ -43,7 +43,7 @@ type UserParam(name : string, paramValue : ParamValue, attributes : IDictionary<
         | _ -> None
 
     override this.ToString() = 
-        $"Name: {(this :> ICvBase).Value}\n\tValue: {(this :> IParamBase).Value}\n\tQualifiers: {this.Keys |> Seq.toList}"
+        $"Name: {(this :> ICvBase).Name}\n\tValue: {(this :> IParamBase).Value}\n\tQualifiers: {this.Keys |> Seq.toList}"
 
     member this.DisplayText = 
         this.ToString()

--- a/src/ControlledVocabulary/UserParam.fs
+++ b/src/ControlledVocabulary/UserParam.fs
@@ -29,6 +29,86 @@ type UserParam(name : string, paramValue : ParamValue, attributes : IDictionary<
     new (name,pv) = 
         UserParam (name,pv,Seq.empty)
 
+    //---------------------- IParam implementations ----------------------//
+
+    /// Returns the value of the Param as a ParamValue
+    static member getParamValue (up: UserParam) = Param.getParamValue up
+
+    /// Returns the value of the Param as IConvertible
+    static member getValue (up: UserParam) = Param.getValue up
+
+    /// Returns the value of the Param as string
+    static member getValueAsString (up: UserParam) = Param.getValueAsString up
+        
+    /// Returns the value of the Param as int if possible, else fails
+    static member getValueAsInt (up: UserParam) = Param.getValueAsInt up
+
+    /// Returns the value of the Param as a term
+    static member getValueAsTerm (up: UserParam) = Param.getValueAsTerm up
+
+    static member tryGetValueAccession (up: UserParam) = Param.tryGetValueAccession up
+
+    static member tryGetValueRef (up: UserParam) = Param.tryGetValueRef up
+
+    static member tryGetCvUnit (up: UserParam) : CvUnit option = Param.tryGetCvUnit up
+
+    static member tryGetCvUnitValue (up: UserParam) = Param.tryGetCvUnitValue up
+
+    static member tryGetCvUnitTermName (up: UserParam) = Param.tryGetCvUnitTermName up
+
+    static member tryGetCvUnitTermAccession (up: UserParam) = Param.tryGetCvUnitTermAccession up
+
+    static member tryGetCvUnitTermRef (up: UserParam) = Param.tryGetCvUnitTermRef up
+
+    static member mapValue (f : ParamValue -> ParamValue) (up: UserParam) = Param.mapValue f up :?> CvParam
+
+    static member tryMapValue (f : ParamValue -> ParamValue option) (up: UserParam) = 
+        Param.tryMapValue f up 
+        |> Option.map (fun v -> v :?> UserParam)
+
+    static member tryAddName (name : string) (up: UserParam) = 
+        Param.tryAddName name up
+        |> Option.map (fun v -> v :?> UserParam)
+
+    static member tryAddAccession (acc : string) (up: UserParam) = 
+        Param.tryAddAccession acc up
+        |> Option.map (fun v -> v :?> UserParam)
+
+    static member tryAddReference (ref : string) (up: UserParam) = 
+        Param.tryAddReference ref up
+        |> Option.map (fun v -> v :?> UserParam)
+
+    static member tryAddUnit (unit : CvUnit) (up: UserParam) = 
+        Param.tryAddUnit unit up
+        |> Option.map (fun v -> v :?> UserParam)
+
+    /// Returns the id of the cv item
+    static member getCvAccession (up: UserParam) = Param.getCvAccession up
+
+    /// Returns the name of the cv item
+    static member getCvName (up: UserParam) = Param.getCvName up
+
+    /// Returns the reference of the cv item
+    static member getCvRef (up: UserParam) = Param.getCvRef up
+
+    /// Returns the full term of the cv item
+    static member getTerm (up: UserParam) = Param.getTerm up
+
+    /// Returns true, if the given term matches the term of the cv item
+    static member equalsTerm (term : CvTerm) (up: UserParam) = Param.equalsTerm term up
+
+    /// Returns true, if the terms of the given param items match
+    static member equals (up1: UserParam) (up2: UserParam) = Param.equals up1 up2
+
+    /// Returns true, if the names of the given param items match
+    static member equalsName (up1: UserParam) (up2: UserParam) = Param.equalsName up1 up2
+
+    /// Returns Some Value of type 'T, if the given param item can be downcast, else returns None
+    static member inline tryAs<'T when 'T :> IParam> (up: UserParam) = Param.tryAs<'T> up
+
+    /// Returns true, if the given param item can be downcast
+    static member inline is<'T when 'T :> IParam> (up: UserParam) = Param.is<'T> up
+
     override this.ToString() = 
         $"Name: {(this :> ICvBase).Name}\n\tValue: {(this :> IParamBase).Value}\n\tQualifiers: {this.Keys |> Seq.toList}"
 

--- a/src/ControlledVocabulary/UserParam.fs
+++ b/src/ControlledVocabulary/UserParam.fs
@@ -9,11 +9,16 @@ type UserParam(name : string, paramValue : ParamValue, attributes : IDictionary<
 
     inherit CvAttributeCollection(attributes)        
 
+    member this.Accession   = name
+    member this.Name        = name
+    member this.RefUri      = "UserTerm"
+    member this.Value       = paramValue
+
     interface IParam with 
-        member this.Accession   = name
-        member this.Name        = name
-        member this.RefUri      = "UserTerm"
-        member this.Value  = paramValue
+        member this.Accession   = this.Accession
+        member this.Name        = this.Name     
+        member this.RefUri      = this.RefUri   
+        member this.Value       = this.Value    
         member this.WithValue(v : ParamValue) = UserParam(name,v,attributes)
         member this.HasAttributes 
             with get() = this.Attributes |> Seq.isEmpty |> not

--- a/src/ControlledVocabulary/UserParam.fs
+++ b/src/ControlledVocabulary/UserParam.fs
@@ -24,26 +24,32 @@ type UserParam(name : string, paramValue : ParamValue, attributes : IDictionary<
     new (name,pv) = 
         UserParam (name,pv,Seq.empty)
 
-    /// Returns Some UserParam, if the given value item can be downcast, else returns None
-    static member tryUserParam (cv : ICvBase) =
-        match cv with
-        | :? UserParam as param -> Some param
-        | _ -> None
-
-    /// Returns Some Param if the given value item can be downcast, else returns None
-    static member tryUserParam (cv : IParamBase) =
-        match cv with
-        | :? UserParam as param -> Some param
-        | _ -> None
-
-    /// Returns Some Param if the given param item can be downcast, else returns None
-    static member tryUserParam (cv : IParam) =
-        match cv with
-        | :? UserParam as param -> Some param
-        | _ -> None
-
     override this.ToString() = 
         $"Name: {(this :> ICvBase).Name}\n\tValue: {(this :> IParamBase).Value}\n\tQualifiers: {this.Keys |> Seq.toList}"
 
     member this.DisplayText = 
         this.ToString()
+
+[<AutoOpen>]
+module UserParamExtensions = 
+
+    type ParamBase with
+        /// Returns Some Param if the given value item can be downcast, else returns None
+        static member tryUserParam (cv : IParamBase) =
+            match cv with
+            | :? UserParam as param -> Some param
+            | _ -> None
+
+    type Param with
+        /// Returns Some Param if the given param item can be downcast, else returns None
+        static member tryUserParam (cv : IParam) =
+            match cv with
+            | :? UserParam as param -> Some param
+            | _ -> None
+
+    type CvBase with
+        /// Returns Some UserParam, if the given value item can be downcast, else returns None
+        static member tryUserParam (cv : ICvBase) =
+            match cv with
+            | :? UserParam as param -> Some param
+            | _ -> None

--- a/tests/ARCTokenization.Tests/IntegrationTests/AssayAnnotationTable.fs
+++ b/tests/ARCTokenization.Tests/IntegrationTests/AssayAnnotationTable.fs
@@ -112,7 +112,7 @@ module Correct  =
                         id = "Term Accession Number (OBI:0100026)",
                         name = "Characteristic [organism]",
                         ref = "Term Source REF (OBI:0100026)",
-                        pv = ParamValue.CvValue (CvTerm.create(accession = "http://purl.obolibrary.org/obo/NCBITaxon_3702", value = "Arabidopsis thaliana", ref = "NCBITaxon")),
+                        pv = ParamValue.CvValue (CvTerm.create(accession = "http://purl.obolibrary.org/obo/NCBITaxon_3702", name = "Arabidopsis thaliana", ref = "NCBITaxon")),
                         attributes = []
                     )
                 ]

--- a/tests/ARCTokenization.Tests/IntegrationTests/AssayAnnotationTable.fs
+++ b/tests/ARCTokenization.Tests/IntegrationTests/AssayAnnotationTable.fs
@@ -112,7 +112,7 @@ module Correct  =
                         id = "Term Accession Number (OBI:0100026)",
                         name = "Characteristic [organism]",
                         ref = "Term Source REF (OBI:0100026)",
-                        pv = (ParamValue.CvValue ("http://purl.obolibrary.org/obo/NCBITaxon_3702","Arabidopsis thaliana","NCBITaxon")),
+                        pv = ParamValue.CvValue (CvTerm.create(accession = "http://purl.obolibrary.org/obo/NCBITaxon_3702", value = "Arabidopsis thaliana", ref = "NCBITaxon")),
                         attributes = []
                     )
                 ]

--- a/tests/ARCTokenization.Tests/IntegrationTests/InvestigationMetadata.fs
+++ b/tests/ARCTokenization.Tests/IntegrationTests/InvestigationMetadata.fs
@@ -108,7 +108,7 @@ let allExpectedMetadataTermsEmpty =
     //]
     Terms.InvestigationMetadata.cvTerms
     |> List.skip 1 //(ignore root term)
-    |> List.map (fun p -> CvParam(p, ParamValue.CvValue (CvTerm("AGMO:00000001", "Metadata Section Key", "AGMO")), []))
+    |> List.map (fun p -> CvParam(p, ParamValue.CvValue (CvTerm.create(accession = "AGMO:00000001", value = "Metadata Section Key", ref = "AGMO")), []))
 
 [<Fact>]
 let ``First Param is CvParam`` () =
@@ -226,7 +226,7 @@ let allExpectedMetadataTermsFull =
         values
         |> List.mapi (fun i v ->
             if i = 0 then
-                CvParam(term, ParamValue.CvValue (CvTerm("AGMO:00000001", "Metadata Section Key", "AGMO")), [])
+                CvParam(term, ParamValue.CvValue (CvTerm.create(accession = "AGMO:00000001", value = "Metadata Section Key", ref = "AGMO")), [])
             else
                 CvParam(term, ParamValue.Value v, [])
         )

--- a/tests/ARCTokenization.Tests/IntegrationTests/InvestigationMetadata.fs
+++ b/tests/ARCTokenization.Tests/IntegrationTests/InvestigationMetadata.fs
@@ -108,7 +108,7 @@ let allExpectedMetadataTermsEmpty =
     //]
     Terms.InvestigationMetadata.cvTerms
     |> List.skip 1 //(ignore root term)
-    |> List.map (fun p -> CvParam(p, ParamValue.CvValue (CvTerm.create(accession = "AGMO:00000001", value = "Metadata Section Key", ref = "AGMO")), []))
+    |> List.map (fun p -> CvParam(p, ParamValue.CvValue (CvTerm.create(accession = "AGMO:00000001", name = "Metadata Section Key", ref = "AGMO")), []))
 
 [<Fact>]
 let ``First Param is CvParam`` () =
@@ -226,7 +226,7 @@ let allExpectedMetadataTermsFull =
         values
         |> List.mapi (fun i v ->
             if i = 0 then
-                CvParam(term, ParamValue.CvValue (CvTerm.create(accession = "AGMO:00000001", value = "Metadata Section Key", ref = "AGMO")), [])
+                CvParam(term, ParamValue.CvValue (CvTerm.create(accession = "AGMO:00000001", name = "Metadata Section Key", ref = "AGMO")), [])
             else
                 CvParam(term, ParamValue.Value v, [])
         )

--- a/tests/ARCTokenization.Tests/IntegrationTests/InvestigationMetadata.fs
+++ b/tests/ARCTokenization.Tests/IntegrationTests/InvestigationMetadata.fs
@@ -112,7 +112,7 @@ let allExpectedMetadataTermsEmpty =
 
 [<Fact>]
 let ``First Param is CvParam`` () =
-    Assert.True (parsedInvestigationMetadataEmpty.Head |> CvParam.tryCvParam).IsSome 
+    Assert.True (parsedInvestigationMetadataEmpty.Head |> Param.tryCvParam).IsSome 
 
 [<Fact>]
 let ``First CvParam`` () = CvParam.structuralEquality (parsedInvestigationMetadataEmpty.Head :?> CvParam) allExpectedMetadataTermsEmpty[0]

--- a/tests/ARCTokenization.Tests/TestUtils.fs
+++ b/tests/ARCTokenization.Tests/TestUtils.fs
@@ -7,16 +7,16 @@ open ARCTokenization.AnnotationTable
 
 module CvParam =
 
-    let termNamesEqual (cvpExpectec : CvParam) (cvpActual : CvParam) =
+    let termValuesEqual (cvpExpectec : CvParam) (cvpActual : CvParam) =
         Assert.Equal(
-            (CvBase.getCvName cvpExpectec),
-            (CvBase.getCvName cvpActual)
+            (CvBase.getCvValue cvpExpectec),
+            (CvBase.getCvValue cvpActual)
         )
 
-    let hasTermName (expectedName : string) (cvpActual : CvParam) =
+    let hasTermValue (expectedValue : string) (cvpActual : CvParam) =
         Assert.Equal(
-            expectedName,
-            (CvBase.getCvName cvpActual)
+            expectedValue,
+            (CvBase.getCvValue cvpActual)
         )
 
     let accessionsEqual (cvpExpectec : CvParam) (cvpActual : CvParam) =
@@ -56,7 +56,7 @@ module CvParam =
         )
 
     let structuralEquality (cvpExpectec : CvParam) (cvpActual : CvParam) =
-        termNamesEqual cvpExpectec cvpActual
+        termValuesEqual cvpExpectec cvpActual
         accessionsEqual cvpExpectec cvpActual
         refUrisEqual cvpExpectec cvpActual
         valuesEqual cvpExpectec cvpActual
@@ -68,8 +68,8 @@ module UserParam =
 
     let termNamesEqual (upActual : UserParam) (upExpectec : UserParam) =
         Assert.Equal(
-            (CvBase.getCvName upActual),
-            (CvBase.getCvName upExpectec)
+            (CvBase.getCvValue upActual),
+            (CvBase.getCvValue upExpectec)
         )
 
 module TokenizedAnnotationTable =

--- a/tests/ARCTokenization.Tests/TestUtils.fs
+++ b/tests/ARCTokenization.Tests/TestUtils.fs
@@ -7,16 +7,16 @@ open ARCTokenization.AnnotationTable
 
 module CvParam =
 
-    let termValuesEqual (cvpExpectec : CvParam) (cvpActual : CvParam) =
+    let termNamesEqual (cvpExpectec : CvParam) (cvpActual : CvParam) =
         Assert.Equal(
-            (CvBase.getCvValue cvpExpectec),
-            (CvBase.getCvValue cvpActual)
+            (CvBase.getCvName cvpExpectec),
+            (CvBase.getCvName cvpActual)
         )
 
     let hasTermValue (expectedValue : string) (cvpActual : CvParam) =
         Assert.Equal(
             expectedValue,
-            (CvBase.getCvValue cvpActual)
+            (CvBase.getCvName cvpActual)
         )
 
     let accessionsEqual (cvpExpectec : CvParam) (cvpActual : CvParam) =
@@ -56,7 +56,7 @@ module CvParam =
         )
 
     let structuralEquality (cvpExpectec : CvParam) (cvpActual : CvParam) =
-        termValuesEqual cvpExpectec cvpActual
+        termNamesEqual cvpExpectec cvpActual
         accessionsEqual cvpExpectec cvpActual
         refUrisEqual cvpExpectec cvpActual
         valuesEqual cvpExpectec cvpActual
@@ -68,8 +68,8 @@ module UserParam =
 
     let termNamesEqual (upActual : UserParam) (upExpectec : UserParam) =
         Assert.Equal(
-            (CvBase.getCvValue upActual),
-            (CvBase.getCvValue upExpectec)
+            (CvBase.getCvName upActual),
+            (CvBase.getCvName upExpectec)
         )
 
 module TokenizedAnnotationTable =

--- a/tests/ControlledVocabulary.Tests/ControlledVocabulary.Tests.fsproj
+++ b/tests/ControlledVocabulary.Tests/ControlledVocabulary.Tests.fsproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="ReferenceObjects.fs" />
+    <Compile Include="CvParamTests.fs" />
     <Compile Include="CvBaseTests.fs" />
     <Compile Include="ParamTests.fs" />
     <Compile Include="ContainerTests.fs" />

--- a/tests/ControlledVocabulary.Tests/CvBaseTests.fs
+++ b/tests/ControlledVocabulary.Tests/CvBaseTests.fs
@@ -3,7 +3,7 @@
 open ControlledVocabulary
 open Xunit
 
-let assayTerm = CvTerm.create(accession = "ARCO:1234", value = "Assay",ref = "ARCO")
+let assayTerm = CvTerm.create(accession = "ARCO:1234", name = "Assay",ref = "ARCO")
 
 [<Fact>]
 let ``ICvBase can be cast to CvParam using generic tryAs`` () = 

--- a/tests/ControlledVocabulary.Tests/CvBaseTests.fs
+++ b/tests/ControlledVocabulary.Tests/CvBaseTests.fs
@@ -19,7 +19,7 @@ let ``ICvBase can be cast to CvParam using generic tryAs`` () =
 [<Fact>]
 let ``ICvBase can be cast to CvParam using tryCvParam`` () =
     let v = CvParam(assayTerm,ParamValue.Value 5) :> ICvBase
-    let result = CvParam.tryCvParam v
+    let result = CvBase.tryCvParam v
     Assert.True(result.IsSome)
 
     let result2 = 
@@ -41,7 +41,7 @@ let ``ICvBase can be cast to UserParam using generic tryAs`` () =
 [<Fact>]
 let ``ICvBase can be cast to UserParam using tryUserParam`` () =
     let v = UserParam("MyParam",ParamValue.Value 5) :> ICvBase
-    let result = UserParam.tryUserParam v
+    let result = CvBase.tryUserParam v
     Assert.True(result.IsSome)
 
     let result2 = 

--- a/tests/ControlledVocabulary.Tests/CvBaseTests.fs
+++ b/tests/ControlledVocabulary.Tests/CvBaseTests.fs
@@ -3,7 +3,7 @@
 open ControlledVocabulary
 open Xunit
 
-let assayTerm = "ARCO:1234","Assay","ARCO"
+let assayTerm = CvTerm.create(accession = "ARCO:1234", value = "Assay",ref = "ARCO")
 
 [<Fact>]
 let ``ICvBase can be cast to CvParam using generic tryAs`` () = 

--- a/tests/ControlledVocabulary.Tests/CvParamTests.fs
+++ b/tests/ControlledVocabulary.Tests/CvParamTests.fs
@@ -1,0 +1,111 @@
+﻿namespace CvParamTests
+
+open ControlledVocabulary
+open ReferenceObjects
+open Xunit
+
+module InstanceMemberTests =
+
+    [<Fact>]
+    let ``Accession`` () =
+        let expected = [testAccession1; testAccession1; testAccession2]
+        let actual = testCvParams |> List.map (fun x -> x.Accession)
+        Assert.Equal<string List>(expected, actual)
+
+    [<Fact>]
+    let ``Name`` () =
+        let expected = [testName1; testName1; testName2]
+        let actual = testCvParams |> List.map (fun x -> x.Name)
+        Assert.Equal<string List>(expected, actual)
+
+    [<Fact>]
+    let ``RefUri`` () =
+        let expected = [testRef1; testRef1; testRef2]
+        let actual = testCvParams |> List.map (fun x -> x.RefUri)
+        Assert.Equal<string List>(expected, actual)
+
+    [<Fact>]
+    let ``Value`` () =
+        let expected = [ParamValue.Value 5; ParamValue.CvValue testTerm2; ParamValue.WithCvUnitAccession (5, testTerm1)]
+        let actual = testCvParams |> List.map (fun x -> x.Value)
+        Assert.Equal<ParamValue List>(expected, actual)
+
+
+module StaticMemberTests =
+
+    [<Fact>]
+    let ``getParamValue`` () =
+        let expected = [ParamValue.Value 5; ParamValue.CvValue testTerm2; ParamValue.WithCvUnitAccession (5, testTerm1)]
+        let actual = testCvParams |> List.map CvParam.getParamValue
+        Assert.Equal<ParamValue List>(expected, actual)
+
+    [<Fact>]
+    let ``getValue`` () =
+        let expected : System.IConvertible list = [5; testTerm2.Name; 5]
+        let actual = testCvParams |> List.map CvParam.getValue
+        Assert.Equal<System.IConvertible List>(expected, actual)
+
+    [<Fact>]
+    let ``getValueAsString`` () =
+        let expected = ["5"; testTerm2.Name; "5"]
+        let actual = testCvParams |> List.map CvParam.getValueAsString
+        Assert.Equal<string List>(expected, actual)
+
+    [<Fact>]
+    let ``getValueAsInt`` () =
+        let expected = [5; 5; 5]
+        let actual = testCvParams |> List.map CvParam.getValueAsInt
+        Assert.Equal<int List>(expected, actual)
+
+    [<Fact>]
+    let ``getValueAsTerm`` () =
+        let expected = [
+            CvTerm.create(name = "5")
+            testTerm2
+            CvTerm.create(name = "5")
+        ]
+        let actual = testCvParams |> List.map CvParam.getValueAsTerm
+        Assert.Equal<CvTerm List>(expected, actual)  
+
+    [<Fact>]
+    let ``tryGetValueAccession`` () =
+        let expected = [None; Some testAccession2; None]
+        let actual = testCvParams |> List.map CvParam.tryGetValueAccession
+        Assert.Equal<Option<string> List>(expected, actual)
+
+    [<Fact>]
+    let ``tryGetValueRef`` () =
+        let expected = [None; Some testRef2; None]
+        let actual = testCvParams |> List.map CvParam.tryGetValueRef
+        Assert.Equal<Option<string> List>(expected, actual)
+
+    [<Fact>]
+    let ``tryGetCvUnit`` () =
+        let expected = [None; None; Some testTerm1]
+        let actual = testCvParams |> List.map CvParam.tryGetCvUnit
+        Assert.Equal<Option<CvUnit> List>(expected, actual)
+
+    [<Fact>]
+    let ``tryGetCvUnitValue`` () =
+        let expected : (System.IConvertible option) list = [None; None; Some 5]
+        let actual = testCvParams |> List.map CvParam.tryGetCvUnitValue
+        Assert.Equal<Option<System.IConvertible> List>(expected, actual)
+
+    [<Fact>]
+    let ``tryGetCvUnitTermName`` () =
+        let expected = [None; None; Some testName1]
+        let actual = testCvParams |> List.map CvParam.tryGetCvUnitTermName
+        Assert.Equal<Option<string> List>(expected, actual)
+
+    [<Fact>]
+    let ``tryGetCvUnitTermAccession`` () =
+        let expected = [None; None; Some testAccession1]
+        let actual = testCvParams |> List.map CvParam.tryGetCvUnitTermAccession
+        Assert.Equal<Option<string> List>(expected, actual)
+
+    [<Fact>]
+    let ``tryGetCvUnitTermRef`` () =
+        let expected = [None; None; Some testRef2]
+        let actual = testCvParams |> List.map CvParam.tryGetCvUnitTermRef
+        Assert.Equal<Option<string> List>(expected, actual)
+

--- a/tests/ControlledVocabulary.Tests/CvParamTests.fs
+++ b/tests/ControlledVocabulary.Tests/CvParamTests.fs
@@ -109,3 +109,105 @@ module StaticMemberTests =
         let actual = testCvParams |> List.map CvParam.tryGetCvUnitTermRef
         Assert.Equal<Option<string> List>(expected, actual)
 
+    [<Fact>]
+    let ``mapValue`` () =
+        let expected = [ParamValue.Value 1; ParamValue.Value 1; ParamValue.Value 1]
+        let actual = testCvParams |> List.map (CvParam.mapValue (fun _ -> ParamValue.Value 1) >> CvParam.getParamValue)
+        Assert.Equal<ParamValue List>(expected, actual)
+    
+    [<Fact>]
+    let ``tryMapValue`` () =
+        let expected = [Some (ParamValue.Value 1); Some (ParamValue.Value 1); Some (ParamValue.Value 1)]
+        let actual = testCvParams |> List.map (CvParam.tryMapValue (fun _ -> Some (ParamValue.Value 1)) >> Option.map CvParam.getParamValue)
+        Assert.Equal<(ParamValue option) List>(expected, actual)
+    
+    [<Fact>]
+    let ``tryAddName`` () =
+        let expected = [Some testName1; None; None]
+        let actual = testCvParams |> List.map (CvParam.tryAddName testName1 >> Option.map CvParam.getCvName)
+        Assert.Equal<(string option) List>(expected, actual)
+
+    [<Fact>]
+    let ``tryAddAccession`` () =
+        let expected = [None; None; None]
+        let actual = testCvParams |> List.map (CvParam.tryAddAccession testAccession1 >> Option.map CvParam.getCvAccession)
+        Assert.Equal<(string option) List>(expected, actual)
+    
+    [<Fact>]
+    let ``tryAddReference`` () =
+        let expected = [None; None; None]
+        let actual = testCvParams |> List.map (CvParam.tryAddReference testRef1 >> Option.map CvParam.getCvRef)
+        Assert.Equal<(string option) List>(expected, actual)
+    
+    [<Fact>]
+    let ``tryAddUnit`` () =
+        let expected = [Some (ParamValue.WithCvUnitAccession (5, testTerm1)); None; None]
+        let actual = testCvParams |> List.map (CvParam.tryAddUnit testTerm1 >> Option.map CvParam.getParamValue)
+        Assert.Equal<(ParamValue option) List>(expected, actual)
+    
+    [<Fact>]
+    let ``getCvAccession`` () =
+        let expected = [testAccession1; testAccession1; testAccession2]
+        let actual = testCvParams |> List.map CvParam.getCvAccession
+        Assert.Equal<string List>(expected, actual)
+    
+    [<Fact>]
+    let ``getCvName`` () =
+        let expected = [testName1; testName1; testName2]
+        let actual = testCvParams |> List.map CvParam.getCvName
+        Assert.Equal<string List>(expected, actual)
+    
+    [<Fact>]
+    let ``getCvRef`` () =
+        let expected = [testRef1; testRef1; testRef2]
+        let actual = testCvParams |> List.map CvParam.getCvRef
+        Assert.Equal<string List>(expected, actual)
+    
+    [<Fact>]
+    let ``getTerm`` () =
+        let expected = [testTerm1; testTerm1; testTerm2]
+        let actual = testCvParams |> List.map CvParam.getTerm
+        Assert.Equal<CvTerm List>(expected, actual)
+
+    [<Fact>]
+    let ``equalsTerm`` () =
+        Assert.All(
+            (
+                List.zip 
+                    [testTerm1; testTerm1; testTerm2]
+                    testCvParams
+            ),
+            (fun (x,y) -> CvParam.equalsTerm x y |> Assert.True)
+        )
+    
+    [<Fact>]
+    let ``equals`` () =
+        Assert.All(
+            (
+                List.zip 
+                    [
+                        CvParam(testTerm1, ParamValue.Value 5)
+                        CvParam(testTerm1, ParamValue.CvValue testTerm2)
+                        CvParam(testTerm2, ParamValue.WithCvUnitAccession (5, testTerm1))
+                    ]
+                    testCvParams
+            ),
+            (fun (x,y) -> CvParam.equals x y |> Assert.True)
+        )
+    
+    [<Fact>]
+    let ``equalsName`` () =
+        Assert.All(
+            (
+                List.zip 
+                    [
+                        CvParam(testTerm1, ParamValue.Value 5)
+                        CvParam(testTerm1, ParamValue.CvValue testTerm2)
+                        CvParam(testTerm2, ParamValue.WithCvUnitAccession (5, testTerm1))
+                    ]
+                    testCvParams
+            ),
+            (fun (x,y) -> CvParam.equalsName x y |> Assert.True)
+        )
+
+

--- a/tests/ControlledVocabulary.Tests/ReferenceObjects.fs
+++ b/tests/ControlledVocabulary.Tests/ReferenceObjects.fs
@@ -1,0 +1,26 @@
+﻿module ReferenceObjects
+
+open ControlledVocabulary
+
+let testAccession1 = "TO:00000001"
+let testName1 = "Test"
+let testRef1 = "TO"
+
+let testTerm1 = CvTerm.create(accession = testAccession1, name = testName1, ref = testRef1)
+
+let testAccession2 = "TO:00000002"
+let testName2 = "5"
+let testRef2 = "TO"
+
+let testTerm2 = CvTerm.create(accession = testAccession2, name = testName2, ref = testRef2)
+
+let ``CvParam with ParamValue.Value`` = CvParam(testTerm1, ParamValue.Value 5)
+let ``CvParam with ParamValue.CvValue`` = CvParam(testTerm1, ParamValue.CvValue testTerm2)
+let ``CvParam with ParamValue.WithCvUnitAccession`` = CvParam(testTerm2, ParamValue.WithCvUnitAccession (5, testTerm1))
+
+let testCvParams = 
+    [
+        ``CvParam with ParamValue.Value``
+        ``CvParam with ParamValue.CvValue``
+        ``CvParam with ParamValue.WithCvUnitAccession``
+    ]


### PR DESCRIPTION
This PR:
- Re-models Cvterm and CvUnit as records
- uses unified naming of CvTerm/CvUnit  record fields across all functions:
  - **Accession** instead of id or AnnotationId
  - **Value** instead of name
  - **RefUri** (instead of ref)
- adds many convenience and accession functions on the modules/types that are actually used in the functions. Example: `tryCvParam`, a function of signature `IParamBase -> CvParam option` will not be on the `CvParam` type anymore, as functions prefixed with `CvParam` are expected to have actual `CvParams` as arguments.