### PR TITLE
#19 Add equality

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,3 @@
 @echo off
-cls
 
 dotnet run --project ./build/Build.fsproj %*

--- a/playground.fsx
+++ b/playground.fsx
@@ -29,16 +29,51 @@ open System.Collections.Generic
 //#r @"C:\Repos\nfdi4plants\ArcGraphModel\src\ArcGraphModel\bin\Debug\netstandard2.0\ArcGraphModel.dll"
 //#r @"C:\Repos\nfdi4plants\ArcGraphModel\src\ArcGraphModel.IO\bin\Debug\netstandard2.0\ArcGraphModel.IO.dll"
 //#r @"C:/Users/olive/.nuget/packages/fsharpaux/1.1.0/lib/net5.0/FSharpAux.dll"
-#r "src/ArcGraphModel/bin/Release/netstandard2.0/ArcGraphModel.dll"
-#r "src/ControlledVocabulary/bin/Release/netstandard2.0/ControlledVocabulary.dll"
+//#r "src/ArcGraphModel/bin/Release/netstandard2.0/ArcGraphModel.dll"
+//#r "src/ControlledVocabulary/bin/Release/netstandard2.0/ControlledVocabulary.dll"
+#I "src/ControlledVocabulary/bin/Debug/netstandard2.0"
+#I "src/ControlledVocabulary/bin/Release/netstandard2.0"
+#r "ControlledVocabulary.dll"
+#I "src/ARCTokenization/bin/Debug/netstandard2.0"
+#I "src/ARCTokenization/bin/Release/netstandard2.0"
+#r "ARCTokenization.dll"
 
 open FsSpreadsheet
 open FsSpreadsheet.ExcelIO
 open FsOboParser
 //open FsSpreadsheet.DSL
 open ControlledVocabulary
-open ControlledVocabulary.ParamBase
+open type ControlledVocabulary.ParamBase
 open ARCTokenization
+
+let testAccession1 = "TO:00000001"
+let testName1 = "Test"
+let testRef1 = "TO"
+
+let testTerm1 = CvTerm.create(accession = testAccession1, name = testName1, ref = testRef1)
+
+let testAccession2 = "TO:00000002"
+let testName2 = "5"
+let testRef2 = "TO"
+
+let testTerm2 = CvTerm.create(accession = testAccession2, name = testName2, ref = testRef2)
+
+let ``CvParam with ParamValue.Value`` = CvParam(testTerm1, ParamValue.Value 5)
+let ``CvParam with ParamValue.CvValue`` = CvParam(testTerm1, ParamValue.CvValue testTerm2)
+let ``CvParam with ParamValue.WithCvUnitAccession`` = CvParam(testTerm2, ParamValue.WithCvUnitAccession (5, testTerm1))
+
+let testCvParams = 
+    [
+        ``CvParam with ParamValue.Value``
+        ``CvParam with ParamValue.CvValue``
+        ``CvParam with ParamValue.WithCvUnitAccession``
+    ]
+let testCvp1 = CvParam("test", "test", "test", ParamValue.Value "test", Dictionary<string,IParam>() |> fun d -> d.Add("test", testCvParams.Head); d) 
+let testCvp2 = CvParam("test", "test", "test", ParamValue.Value "test", Dictionary<string,IParam>() |> fun d -> d.Add("test", testCvParams.Head); d) 
+let actual = testCvp1 = testCvp2
+testCvp1.GetHashCode()
+testCvp2.GetHashCode()
+
 
 
 let expectedTermValuesSimple = 

--- a/src/ControlledVocabulary/CvContainer.fs
+++ b/src/ControlledVocabulary/CvContainer.fs
@@ -44,12 +44,19 @@ type CvContainer (
         CvContainer(term, dict)
     new (term : CvTerm) = CvContainer (term, Seq.empty)  
 
+    /// Serves as the default hash function.
     override this.GetHashCode() =
         hash (cvAccession, cvName, cvRef, attributes, properties)
 
+    /// Determines whether the specified object is equals to the current object.
     override this.Equals(o) =
         match o with
-        | :? CvContainer as cvc -> cvc.GetHashCode() = this.GetHashCode()
+        | :? CvContainer as cvc -> 
+            (cvc :> ICvBase).Accession = (this :> ICvBase).Accession &&
+            (cvc :> ICvBase).Name = (this :> ICvBase).Name &&
+            (cvc :> ICvBase).RefUri = (this :> ICvBase).RefUri &&
+            cvc.Attributes = this.Attributes &&
+            cvc.Properties = this.Properties
         | :? ICvBase as cvb -> CvBase.equals cvb this
         | _ -> false
 

--- a/src/ControlledVocabulary/CvContainer.fs
+++ b/src/ControlledVocabulary/CvContainer.fs
@@ -44,6 +44,15 @@ type CvContainer (
         CvContainer(term, dict)
     new (term : CvTerm) = CvContainer (term, Seq.empty)  
 
+    override this.GetHashCode() =
+        hash (cvAccession, cvName, cvRef, attributes, properties)
+
+    override this.Equals(o) =
+        match o with
+        | :? CvContainer as cvc -> cvc.GetHashCode() = this.GetHashCode()
+        | :? ICvBase as cvb -> CvBase.equals cvb this
+        | _ -> false
+
     /// Returns Some CvContainer, if the given cv item can be downcast, else returns None
     static member tryCvContainer (cv : ICvBase) =
         match cv with

--- a/src/ControlledVocabulary/CvObject.fs
+++ b/src/ControlledVocabulary/CvObject.fs
@@ -18,9 +18,7 @@ type CvObject<'T>(cvAccession : string, cvName : string, cvRef : string, object 
 
     override this.Equals(o) =
         match o with
-        | :? CvObject<'T> as cvo ->
-            CvBase.equals cvo this &&
-            cvo.Attributes = this.Attributes
+        | :? CvObject<'T> as cvo -> this.GetHashCode() = cvo.GetHashCode()
         | :? ICvBase as cvb -> CvBase.equals cvb this
         | _ -> false
 

--- a/src/ControlledVocabulary/CvObject.fs
+++ b/src/ControlledVocabulary/CvObject.fs
@@ -16,6 +16,17 @@ type CvObject<'T>(cvAccession : string, cvName : string, cvRef : string, object 
 
     new (term: CvTerm, object : 'T, attributes) = CvObject (term.Accession, term.Name, term.RefUri, object, attributes)
 
+    override this.Equals(o) =
+        match o with
+        | :? CvObject<'T> as cvo ->
+            CvBase.equals cvo this &&
+            cvo.Attributes = this.Attributes
+        | :? ICvBase as cvb -> CvBase.equals cvb this
+        | _ -> false
+
+    override this.GetHashCode() =
+        hash (cvAccession, cvName, cvRef, attributes)
+
     member this.Object = object
 
     override this.ToString() = 

--- a/src/ControlledVocabulary/CvObject.fs
+++ b/src/ControlledVocabulary/CvObject.fs
@@ -22,6 +22,7 @@ type CvObject<'T>(cvAccession : string, cvName : string, cvRef : string, object 
         | :? ICvBase as cvb -> CvBase.equals cvb this
         | _ -> false
 
+    /// Serves as the default hash function.
     override this.GetHashCode() =
         hash (cvAccession, cvName, cvRef, attributes)
 

--- a/src/ControlledVocabulary/CvParam.fs
+++ b/src/ControlledVocabulary/CvParam.fs
@@ -45,14 +45,26 @@ type CvParam(cvAccession : string, cvName : string, cvRef : string, paramValue :
     new (cvTerm,v : IConvertible) = 
         CvParam (cvTerm,ParamValue.Value v)
 
-    member this.Equals (term : CvTerm) = 
-        Param.equalsTerm term this
+    override this.GetHashCode() =
+        hash (cvAccession, cvName, cvRef, paramValue, attributes)
 
-    member this.Equals (cv : ICvBase) = 
-        CvBase.equals cv this
-
-    member this.Equals (cvp : CvParam) =
-        this.Equals(cvp :> ICvBase)
+    override this.Equals(o) =
+        match o with
+        | :? CvTerm as cvt -> Param.equalsTerm cvt this
+        | :? CvParam as cvp ->
+            cvp.Name        = this.Name &&
+            cvp.Accession   = this.Accession &&
+            cvp.RefUri      = this.RefUri &&
+            cvp.Value       = this.Value &&
+            cvp.Attributes  = this.Attributes   // careful bc of Dictionary! Comment out if necessary!
+        | :? IParam as p ->
+            p.Name      = this.Name &&
+            p.Accession = this.Accession &&
+            p.RefUri    = this.Name &&
+            p.Value     = this.Value
+        | :? ICvBase as cvb -> CvBase.equals cvb this
+        | :? IParamBase as pb -> pb.Value = this.Value
+        | _ -> false
 
     //---------------------- IParam implementations ----------------------//
 

--- a/src/ControlledVocabulary/CvParam.fs
+++ b/src/ControlledVocabulary/CvParam.fs
@@ -51,12 +51,7 @@ type CvParam(cvAccession : string, cvName : string, cvRef : string, paramValue :
     override this.Equals(o) =
         match o with
         | :? CvTerm as cvt -> Param.equalsTerm cvt this
-        | :? CvParam as cvp ->
-            cvp.Name        = this.Name &&
-            cvp.Accession   = this.Accession &&
-            cvp.RefUri      = this.RefUri &&
-            cvp.Value       = this.Value &&
-            cvp.Attributes  = this.Attributes   // careful bc of Dictionary! Comment out if necessary!
+        | :? CvParam as cvp -> cvp.GetHashCode() = this.GetHashCode()
         | :? IParam as p ->
             p.Name      = this.Name &&
             p.Accession = this.Accession &&

--- a/src/ControlledVocabulary/CvParam.fs
+++ b/src/ControlledVocabulary/CvParam.fs
@@ -45,13 +45,20 @@ type CvParam(cvAccession : string, cvName : string, cvRef : string, paramValue :
     new (cvTerm,v : IConvertible) = 
         CvParam (cvTerm,ParamValue.Value v)
 
+    /// Serves as the default hash function.
     override this.GetHashCode() =
         hash (cvAccession, cvName, cvRef, paramValue, attributes)
 
+    /// Determines whether the specified object is equals to the current object.
     override this.Equals(o) =
         match o with
         | :? CvTerm as cvt -> Param.equalsTerm cvt this
-        | :? CvParam as cvp -> cvp.GetHashCode() = this.GetHashCode()
+        | :? CvParam as cvp -> 
+            cvp.Name        = this.Name &&
+            cvp.Accession   = this.Accession &&
+            cvp.RefUri      = this.RefUri &&
+            cvp.Value       = this.Value &&
+            cvp.Attributes  = this.Attributes   // careful bc of Dictionary! Comment out if necessary!
         | :? IParam as p ->
             p.Name      = this.Name &&
             p.Accession = this.Accession &&

--- a/src/ControlledVocabulary/UserParam.fs
+++ b/src/ControlledVocabulary/UserParam.fs
@@ -31,13 +31,18 @@ type UserParam(name : string, paramValue : ParamValue, attributes : IDictionary<
     new (name,pv) = 
         UserParam (name,pv,Seq.empty)
 
+    /// Serves as the default hash function.
     override this.GetHashCode() =
         hash (name, paramValue, attributes)
 
+    /// Determines whether the specified object is equals to the current object.
     override this.Equals(o) =
         match o with
         | :? CvTerm as cvt -> Param.equalsTerm cvt this
-        | :? UserParam as up -> this.GetHashCode() = up.GetHashCode()
+        | :? UserParam as up -> 
+            up.Name         = this.Name &&
+            up.Value        = this.Value &&
+            up.Attributes   = this.Attributes
         | :? IParam as p ->
             p.Name  = this.Name &&
             p.Value = this.Value

--- a/src/ControlledVocabulary/UserParam.fs
+++ b/src/ControlledVocabulary/UserParam.fs
@@ -37,13 +37,10 @@ type UserParam(name : string, paramValue : ParamValue, attributes : IDictionary<
     override this.Equals(o) =
         match o with
         | :? CvTerm as cvt -> Param.equalsTerm cvt this
-        | :? UserParam as up ->
-            up.Name         = this.Name &&
-            up.Value        = this.Value &&
-            up.Attributes   = this.Attributes
+        | :? UserParam as up -> this.GetHashCode() = up.GetHashCode()
         | :? IParam as p ->
-            p.Name          = this.Name &&
-            p.Value         = this.Value
+            p.Name  = this.Name &&
+            p.Value = this.Value
         | :? ICvBase as cvb -> CvBase.equals cvb this
         | :? IParamBase as pb -> pb.Value = this.Value
         | _ -> false

--- a/src/ControlledVocabulary/UserParam.fs
+++ b/src/ControlledVocabulary/UserParam.fs
@@ -31,6 +31,23 @@ type UserParam(name : string, paramValue : ParamValue, attributes : IDictionary<
     new (name,pv) = 
         UserParam (name,pv,Seq.empty)
 
+    override this.GetHashCode() =
+        hash (name, paramValue, attributes)
+
+    override this.Equals(o) =
+        match o with
+        | :? CvTerm as cvt -> Param.equalsTerm cvt this
+        | :? UserParam as up ->
+            up.Name         = this.Name &&
+            up.Value        = this.Value &&
+            up.Attributes   = this.Attributes
+        | :? IParam as p ->
+            p.Name          = this.Name &&
+            p.Value         = this.Value
+        | :? ICvBase as cvb -> CvBase.equals cvb this
+        | :? IParamBase as pb -> pb.Value = this.Value
+        | _ -> false
+
     //---------------------- IParam implementations ----------------------//
 
     /// Returns the value of the Param as a ParamValue

--- a/tests/ControlledVocabulary.Tests/CvParamTests.fs
+++ b/tests/ControlledVocabulary.Tests/CvParamTests.fs
@@ -34,12 +34,47 @@ module InstanceMemberTests =
         let actual = testCvParams |> List.map (fun x -> x.Value)
         Assert.Equal<ParamValue List>(expected, actual)
 
-    [<Fact>]
-    let ``Equals`` () =
+    module ``Equals`` =
+
         let testCvp1 = CvParam("test", "test", "test", ParamValue.Value "test", Generic.Dictionary<string,IParam>() |> fun d -> d.Add("test", testCvParams.Head); d) 
         let testCvp2 = CvParam("test", "test", "test", ParamValue.Value "test", Generic.Dictionary<string,IParam>() |> fun d -> d.Add("test", testCvParams.Head); d) 
-        let actual = testCvp1 = testCvp2
-        Assert.True(actual)
+        let testAttr1 = CvAttributeCollection(Generic.Dictionary<string,IParam>() |> fun d -> d.Add("test", testCvp1); d)
+        let testCvp3 = CvParam("test", "test", "test", ParamValue.Value "test")
+        let testCvp4 = CvParam("test", "test", "test", ParamValue.Value "test")
+        let testCvp5 = CvParam("test", "test", "test", ParamValue.Value "test", Generic.Dictionary<string,IParam>() |> fun d -> d.Add("test", testCvp1); d)
+        let testCvp6 = CvParam("test", "test", "test", ParamValue.Value "test", Generic.Dictionary<string,IParam>() |> fun d -> d.Add("test", testCvp2); d)
+        let testCvp7 = CvParam("", "", "", ParamValue.Value "", Generic.Dictionary<string,IParam>() |> fun d -> d.Add("test", testCvParams[1]); d)
+        let testCvp8 = CvParam("", "", "", ParamValue.Value "", Generic.Dictionary<string,IParam>() |> fun d -> d.Add("test", testCvp7); d)
+
+        [<Fact>]
+        let ``identical CvParams, empty Attributes with empty Attributes`` () =
+            let actual = testCvp3 = testCvp4
+            Assert.True actual
+
+        [<Fact>]
+        let ``identical CvParams, filled Attributes with empty Attributes`` () =
+            let actual = testCvp1 = testCvp2
+            Assert.True actual
+
+        [<Fact>]
+        let ``identical CvParams, filled Attributes with filled Attributes`` () =
+            let actual = testCvp5 = testCvp6
+            Assert.True actual
+
+        [<Fact>]
+        let ``different CvParams, empty Attributes with empty Attributes`` () =
+            let actual = testCvp3 = testCvParams.Head
+            Assert.False actual
+
+        [<Fact>]
+        let ``different CvParams, filled Attributes with empty Attributes`` () =
+            let actual = testCvp1 = testCvp7
+            Assert.False actual
+
+        [<Fact>]
+        let ``different CvParams, filled Attributes with filled Attributes`` () =
+            let actual = testCvp5 = testCvp8
+            Assert.False actual
 
 
 module StaticMemberTests =

--- a/tests/ControlledVocabulary.Tests/CvParamTests.fs
+++ b/tests/ControlledVocabulary.Tests/CvParamTests.fs
@@ -2,7 +2,11 @@
 
 open ControlledVocabulary
 open ReferenceObjects
+
 open Xunit
+
+open System.Collections
+
 
 module InstanceMemberTests =
 
@@ -29,6 +33,13 @@ module InstanceMemberTests =
         let expected = [ParamValue.Value 5; ParamValue.CvValue testTerm2; ParamValue.WithCvUnitAccession (5, testTerm1)]
         let actual = testCvParams |> List.map (fun x -> x.Value)
         Assert.Equal<ParamValue List>(expected, actual)
+
+    [<Fact>]
+    let ``Equals`` () =
+        let testCvp1 = CvParam("test", "test", "test", ParamValue.Value "test", Generic.Dictionary<string,IParam>() |> fun d -> d.Add("test", testCvParams.Head); d) 
+        let testCvp2 = CvParam("test", "test", "test", ParamValue.Value "test", Generic.Dictionary<string,IParam>() |> fun d -> d.Add("test", testCvParams.Head); d) 
+        let actual = testCvp1 = testCvp2
+        Assert.True(actual)
 
 
 module StaticMemberTests =


### PR DESCRIPTION
This PR
- overrides standard `.Equals()` method for
  - UserParam
  - CvParam
  - CvContainer
- adds respective unit tests to CvParam
- overrides standard `.GetHashCode()` method as adviced by the compiler for
  - UserParam
  - CvParam
  - CvObject
  - CvContainer
- closes #19 