### PR TITLE
URI 2 TAN on creation

### DIFF
--- a/src/ControlledVocabulary/CvTerm.fs
+++ b/src/ControlledVocabulary/CvTerm.fs
@@ -1,5 +1,9 @@
 ﻿namespace ControlledVocabulary
 
+
+open FSharpAux
+
+
 /// Represents a term from a controlled vocabulary (Cv)
 /// in the form of: id|accession ; name|value ; refUri
 // ?Maybe [<Struct>]
@@ -9,6 +13,15 @@ type CvTerm = {
     Name: string
     RefUri: string
 } with
+
+    /// <summary>
+    /// Checks if the given accession is an URI.
+    /// </summary>
+    /// <param name="accession">The input accession.</param>
+    static member checkForUri accession =
+        let rx = System.Text.RegularExpressions.Regex("^https?:\/\/[a-zA-Z0-9\/]+\/[a-zA-Z]+_[0-9]+\/?$")
+        rx.Match(accession).Success
+
     static member create(
         accession: string,
         name: string,

--- a/src/ControlledVocabulary/CvTerm.fs
+++ b/src/ControlledVocabulary/CvTerm.fs
@@ -22,13 +22,38 @@ type CvTerm = {
         let rx = System.Text.RegularExpressions.Regex("^https?:\/\/[a-zA-Z0-9\/]+\/[a-zA-Z]+_[0-9]+\/?$")
         rx.Match(accession).Success
 
+    /// <summary>
+    /// Takes an URI and returns the respective TAN.
+    /// </summary>
+    /// <param name="uri">The input URI.</param>
+    static member uriToTan (uri : string) : string =
+        let posLastSlash = String.findIndexBack '/' uri
+        uri[posLastSlash + 1 ..]
+        |> String.replace "_" ":"
+
+    /// <summary>
+    /// Creates a CvTerm from a given accession, name and reference.
+    /// </summary>
+    /// <param name="accession">The accession of the term.</param>
+    /// <param name="name">The name of the term.</param>
+    /// <param name="ref">The term source reference of the term.</param>
     static member create(
         accession: string,
         name: string,
         ref : string
     ) = 
-        {Accession = accession; Name = name; RefUri = ref}
 
+        let tanAccession =
+            if CvTerm.checkForUri accession then 
+                CvTerm.uriToTan accession
+            else accession
+
+        {Accession = tanAccession; Name = name; RefUri = ref}
+
+    /// <summary>
+    /// Creates a CvTerm from a given name. Accession and reference are empty.
+    /// </summary>
+    /// <param name="name">The name of the term.</param>
     static member create(
         name: string
     ) = 

--- a/src/ControlledVocabulary/CvTerm.fs
+++ b/src/ControlledVocabulary/CvTerm.fs
@@ -19,7 +19,7 @@ type CvTerm = {
     /// </summary>
     /// <param name="accession">The input accession.</param>
     static member checkForUri accession =
-        let rx = System.Text.RegularExpressions.Regex("^https?:\/\/[a-zA-Z0-9\/]+\/[a-zA-Z]+_[0-9]+\/?$")
+        let rx = System.Text.RegularExpressions.Regex("^https?:\/\/[a-zA-Z0-9\/.]+\/[a-zA-Z]+_[0-9]+\/?$")
         rx.Match(accession).Success
 
     /// <summary>

--- a/tests/ControlledVocabulary.Tests/ControlledVocabulary.Tests.fsproj
+++ b/tests/ControlledVocabulary.Tests/ControlledVocabulary.Tests.fsproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <Compile Include="ReferenceObjects.fs" />
+    <Compile Include="CvTermTests.fs" />
     <Compile Include="CvParamTests.fs" />
     <Compile Include="CvBaseTests.fs" />
     <Compile Include="ParamTests.fs" />

--- a/tests/ControlledVocabulary.Tests/CvTermTests.fs
+++ b/tests/ControlledVocabulary.Tests/CvTermTests.fs
@@ -1,0 +1,55 @@
+﻿namespace CvTermTests
+
+
+open ControlledVocabulary
+open ReferenceObjects
+
+open Xunit
+
+
+module CheckForUri =
+
+    [<Fact>]
+    let ``correct check, actual URL 1`` () =
+        let check = CvTerm.checkForUri testAccession3
+        Assert.True check
+
+    [<Fact>]
+    let ``correct check, actual URL 2`` () =
+        let check = CvTerm.checkForUri "https://purl.org/TO_00000003"
+        Assert.True check
+
+    [<Fact>]
+    let ``correct check, no URL`` () =
+        let check = CvTerm.checkForUri "purl/123_abc"
+        Assert.False check
+
+
+module UriToTan =
+
+    [<Fact>]
+    let ``correct TAN returned`` () =
+        let expected = "TO:00000003"
+        let actual = CvTerm.uriToTan testAccession3
+        Assert.Equal(expected, actual)
+
+
+module Create =
+
+    [<Fact>]
+    let ``correct CvTerm, primary create function overload`` () =
+        let expected = testTerm1
+        let actual = CvTerm.create(testAccession1, testName1, testRef1)
+        Assert.Equal(expected, actual)
+
+    [<Fact>]
+    let ``correct CvTerm, secondary create function overload (only name given)`` () =
+        let expected = testTerm4
+        let actual = CvTerm.create(testName2)
+        Assert.Equal(expected, actual)
+
+    [<Fact>]
+    let ``correct CvTerm, create function with URL as accession`` () =
+        let expected = testTerm3
+        let actual = CvTerm.create(testAccession3, testName2, testRef2)
+        Assert.Equal(expected, actual)

--- a/tests/ControlledVocabulary.Tests/ReferenceObjects.fs
+++ b/tests/ControlledVocabulary.Tests/ReferenceObjects.fs
@@ -1,18 +1,42 @@
 ﻿module ReferenceObjects
 
+
 open ControlledVocabulary
+
 
 let testAccession1 = "TO:00000001"
 let testName1 = "Test"
 let testRef1 = "TO"
 
-let testTerm1 = CvTerm.create(accession = testAccession1, name = testName1, ref = testRef1)
+let testTerm1 = {
+    Accession   = testAccession1
+    Name        = testName1
+    RefUri      = testRef1
+}
 
 let testAccession2 = "TO:00000002"
 let testName2 = "5"
 let testRef2 = "TO"
 
-let testTerm2 = CvTerm.create(accession = testAccession2, name = testName2, ref = testRef2)
+let testTerm2 = {
+    Accession   = testAccession2
+    Name        = testName2
+    RefUri      = testRef2
+}
+
+let testAccession3 = "http://purl.org/TO_00000003"
+
+let testTerm3 = {
+    Accession   = "TO:00000003"
+    Name        = testName2
+    RefUri      = testRef2
+}
+
+let testTerm4 = {
+    Accession   = ""
+    Name        = testName2
+    RefUri      = ""
+}
 
 let ``CvParam with ParamValue.Value`` = CvParam(testTerm1, ParamValue.Value 5)
 let ``CvParam with ParamValue.CvValue`` = CvParam(testTerm1, ParamValue.CvValue testTerm2)


### PR DESCRIPTION
This PR
- adds functionality to `CvTerm` type to turn an URI to a TAN directly on creation.
  - adds functions to the type for the steps inbetween (check for URI, turn URI to TAN)
  - adds tests for the whole type and its members
  - closes #61