### PR TITLE
TSR from TAN

### DIFF
--- a/src/ControlledVocabulary/CvTerm.fs
+++ b/src/ControlledVocabulary/CvTerm.fs
@@ -31,6 +31,11 @@ type CvTerm = {
         uri[posLastSlash + 1 ..]
         |> String.replace "_" ":"
 
+    /// Returns the corresponding Term Source Ref from the given Term Number Accession.
+    static member refOfAccession accession =
+        let m = System.Text.RegularExpressions.Regex.Match(accession, @"^(?<TermSourceRef>[A-Za-z]+):(\d+)$")
+        m.Groups["TermSourceRef"].Value
+
     /// <summary>
     /// Creates a CvTerm from a given accession, name and reference.
     /// </summary>

--- a/tests/ControlledVocabulary.Tests/CvTermTests.fs
+++ b/tests/ControlledVocabulary.Tests/CvTermTests.fs
@@ -34,6 +34,15 @@ module UriToTan =
         Assert.Equal(expected, actual)
 
 
+module RefOfAccession =
+
+    [<Fact>]
+    let ``correct TSR returned`` () =
+        let expected = "TO"
+        let actual = CvTerm.refOfAccession testAccession1
+        Assert.Equal(expected, actual)
+
+
 module Create =
 
     [<Fact>]


### PR DESCRIPTION
This PR
- provides the `CvTerm` namespace with a function to get a TSR from a given TAN
- adds a unit test accordingly
- closes #73 